### PR TITLE
load_from_self - an ability to load config definitions from the current __FILE__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Instant configuration via block `config = Config.new { |conf| <<your configuration code>> }`;
 - `.load_from_yaml` command - an ability to define config settings by loading them from a yaml file;
+- `.load_from_self` command - an ability to load config definitions form the YAML
+  instructions written in the file where your config class is defined;
 - `#reload!` - an ability to reload config isntance after any config class changes and updates;
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -292,7 +292,6 @@ config.reload! # => Qonfig::FrozenSettingsError
 
 ### Load from YAML file
 
-
 ```yaml
 <!-- travis.yml -->
 sudo: false
@@ -362,6 +361,8 @@ connection_timeout:
    seconds: 10
    enabled: false
 ```
+
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ require 'qonfig'
 - [Hash representation](#hash-representation)
 - [State freeze](#state-freeze)
 - [Reload](#reload)
-- [Load from .yml](#load-from-yml)
+- [Load from YAML file](#load-from-yaml-file)
+- [Load from self](#load-from-self)
 
 ---
 
@@ -289,7 +290,7 @@ config.reload! # => Qonfig::FrozenSettingsError
 
 ---
 
-### Load from .yml
+### Load from YAML file
 
 
 ```yaml
@@ -327,6 +328,40 @@ config.settings['Sidekiq/Scheduler']['enable'] #=> true
 ```
 
 ---
+
+### Load from self
+
+```ruby
+class Config < Qonfig::DataSet
+  load_from_self # on the root
+
+  setting :clowd do
+    load_from_self # nested
+  end
+end
+
+config = Config.new
+
+# on the root
+config.settings.secret_key # => 'top-mega-secret'
+config.settings.api_host # => 'super.puper-google.com'
+config.settings.connection_timeout.seconds # => 10
+config.settings.connection_timeout.enabled # => false
+
+# nested
+config.settings.nested.secret_key # => 'top-mega-secret'
+config.settings.nested.api_host # => 'super.puper-google.com'
+config.settings.nested.connection_timeout.seconds # => 10
+config.settings.nested.connection_timeout.enabled # => false
+
+__END__
+
+secret_key: top-mega-secret
+api_host: super.puper-google.com
+connection_timeout:
+   seconds: 10
+   enabled: false
+```
 
 ## License
 

--- a/lib/qonfig.rb
+++ b/lib/qonfig.rb
@@ -9,6 +9,7 @@ module Qonfig
   require_relative 'qonfig/commands/add_nested_option'
   require_relative 'qonfig/commands/compose'
   require_relative 'qonfig/commands/load_from_yaml'
+  require_relative 'qonfig/commands/load_from_self'
   require_relative 'qonfig/command_set'
   require_relative 'qonfig/settings'
   require_relative 'qonfig/settings_builder'

--- a/lib/qonfig.rb
+++ b/lib/qonfig.rb
@@ -15,4 +15,5 @@ module Qonfig
   require_relative 'qonfig/settings_builder'
   require_relative 'qonfig/dsl'
   require_relative 'qonfig/data_set'
+  require_relative 'qonfig/data_set/class_builder'
 end

--- a/lib/qonfig/commands/load_from_self.rb
+++ b/lib/qonfig/commands/load_from_self.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Qonfig
+  class Commands
+    # @api private
+    # @since 0.2.0
+    class LoadFromSelf < Base
+      # @return [String]
+      #
+      # @api private
+      # @since 0.2.0
+      attr_reader :self_data
+
+      # @param self_data [String]
+      #
+      # @api private
+      # @sicne 0.2.0
+      def initialize(self_data)
+        @self_data = self_data
+      end
+
+      # @param settings [Qonfig::Settings]
+      # @return [void]
+      #
+      # @api private
+      # @since 0.2.0
+      def call(settings)
+        # TODO: implement
+      end
+    end
+  end
+end

--- a/lib/qonfig/commands/load_from_self.rb
+++ b/lib/qonfig/commands/load_from_self.rb
@@ -43,12 +43,15 @@ module Qonfig
       # @since 0.2.0
       def load_self_placed_yaml_data
         caller_file = caller_location.split(':').first
+
+        # :nocov:
         unless File.exist?(caller_file)
           raise(
             Qonfig::SelfDataNotFoundError,
             "Caller file does not exist! (location: #{caller_location})"
           )
         end
+        # :nocov:
 
         data_match = IO.read(caller_file).match(/\n__END__\n(?<end_data>.*)/m)
         raise Qonfig::SelfDataNotFoundError, '__END__ data not found!' unless data_match

--- a/lib/qonfig/commands/load_from_self.rb
+++ b/lib/qonfig/commands/load_from_self.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Qonfig
-  class Commands
+  module Commands
     # @api private
     # @since 0.2.0
     class LoadFromSelf < Base
@@ -9,14 +9,14 @@ module Qonfig
       #
       # @api private
       # @since 0.2.0
-      attr_reader :self_data
+      attr_reader :caller_location
 
-      # @param self_data [String]
+      # @param caller_location [String]
       #
       # @api private
       # @sicne 0.2.0
-      def initialize(self_data)
-        @self_data = self_data
+      def initialize(caller_location)
+        @caller_location = caller_location
       end
 
       # @param settings [Qonfig::Settings]
@@ -25,7 +25,38 @@ module Qonfig
       # @api private
       # @since 0.2.0
       def call(settings)
-        # TODO: implement
+        caller_file = caller_location.split(':').first
+        data_match = IO.read(caller_file).match(/\n__END__\n(?<end_data>.*)/m)
+        raise Qonfig::SelfDataNotFoundError, '__END__ data not found!' unless data_match
+        file_data = data_match[:end_data]
+        raise Qonfig::SelfDataNotFoundError, '__END__ data not found!' unless file_data
+        yaml_data = Psych.load(file_data)
+        unless yaml_data.is_a?(Hash)
+          raise Qonfig::IncompatibleYAMLError, 'YAML data should have a hash-like structure'
+        end
+        yaml_based_settings = build_data_set_klass(yaml_data).new.settings
+        settings.__append_settings__(yaml_based_settings)
+      end
+
+      private
+
+      # @param [Hash]
+      # @return [Class<Qonfig::DataSet>]
+      #
+      # @api private
+      # @since 0.2.0
+      def build_data_set_klass(hash)
+        Class.new(Qonfig::DataSet).tap do |data_set_klass|
+          hash.each_pair do |key, value|
+            if value.is_a?(Hash)
+              sub_data_set_klass = build_data_set_klass(hash[key])
+
+              data_set_klass.setting(key) { compose sub_data_set_klass }
+            else
+              data_set_klass.setting key, value
+            end
+          end
+        end
       end
     end
   end

--- a/lib/qonfig/commands/load_from_self.rb
+++ b/lib/qonfig/commands/load_from_self.rb
@@ -25,38 +25,52 @@ module Qonfig
       # @api private
       # @since 0.2.0
       def call(settings)
-        caller_file = caller_location.split(':').first
-        data_match = IO.read(caller_file).match(/\n__END__\n(?<end_data>.*)/m)
-        raise Qonfig::SelfDataNotFoundError, '__END__ data not found!' unless data_match
-        file_data = data_match[:end_data]
-        raise Qonfig::SelfDataNotFoundError, '__END__ data not found!' unless file_data
-        yaml_data = Psych.load(file_data)
-        unless yaml_data.is_a?(Hash)
-          raise Qonfig::IncompatibleYAMLError, 'YAML data should have a hash-like structure'
-        end
+        yaml_data = load_self_placed_yaml_data
+
         yaml_based_settings = build_data_set_klass(yaml_data).new.settings
+
         settings.__append_settings__(yaml_based_settings)
       end
 
       private
 
-      # @param [Hash]
+      # @return [Hash]
+      #
+      # @raise [Qonfig::SelfDataNotFound]
+      # @raise [Qonfig::IncompatibleYamlError]
+      #
+      # @api private
+      # @since 0.2.0
+      def load_self_placed_yaml_data
+        caller_file = caller_location.split(':').first
+        unless File.exist?(caller_file)
+          raise(
+            Qonfig::SelfDataNotFoundError,
+            "Caller file does not exist! (location: #{caller_location})"
+          )
+        end
+
+        data_match = IO.read(caller_file).match(/\n__END__\n(?<end_data>.*)/m)
+        raise Qonfig::SelfDataNotFoundError, '__END__ data not found!' unless data_match
+
+        end_data = data_match[:end_data]
+        raise Qonfig::SelfDataNotFoundError, '__END__ data not found!' unless end_data
+
+        yaml_data = Psych.load(end_data)
+        unless yaml_data.is_a?(Hash)
+          raise Qonfig::IncompatibleYAMLError, 'YAML data should have a hash-like structure'
+        end
+
+        yaml_data
+      end
+
+      # @param self_placed_yaml_data [Hash]
       # @return [Class<Qonfig::DataSet>]
       #
       # @api private
       # @since 0.2.0
-      def build_data_set_klass(hash)
-        Class.new(Qonfig::DataSet).tap do |data_set_klass|
-          hash.each_pair do |key, value|
-            if value.is_a?(Hash)
-              sub_data_set_klass = build_data_set_klass(hash[key])
-
-              data_set_klass.setting(key) { compose sub_data_set_klass }
-            else
-              data_set_klass.setting key, value
-            end
-          end
-        end
+      def build_data_set_klass(self_placed_yaml_data)
+        Qonfig::DataSet::ClassBuilder.build_from_hash(self_placed_yaml_data)
       end
     end
   end

--- a/lib/qonfig/commands/load_from_yaml.rb
+++ b/lib/qonfig/commands/load_from_yaml.rb
@@ -32,29 +32,20 @@ module Qonfig
           raise Qonfig::IncompatibleYAMLError, 'YAML file should have a hash-like structure'
         end
 
-        yaml_based_settings = build_data_set_klass(yaml_data).new.settings
+        yaml_based_settings = build_data_set_class(yaml_data).new.settings
+
         settings.__append_settings__(yaml_based_settings)
       end
 
       private
 
-      # @param [Hash]
+      # @param yaml_data [Hash]
       # @return [Class<Qonfig::DataSet>]
       #
       # @api private
       # @since 0.2.0
-      def build_data_set_klass(hash)
-        Class.new(Qonfig::DataSet).tap do |data_set_klass|
-          hash.each_pair do |key, value|
-            if value.is_a?(Hash)
-              sub_data_set_klass = build_data_set_klass(hash[key])
-
-              data_set_klass.setting(key) { compose sub_data_set_klass }
-            else
-              data_set_klass.setting key, value
-            end
-          end
-        end
+      def build_data_set_class(yaml_data)
+        Qonfig::DataSet::ClassBuilder.build_from_hash(yaml_data)
       end
     end
   end

--- a/lib/qonfig/data_set/class_builder.rb
+++ b/lib/qonfig/data_set/class_builder.rb
@@ -1,23 +1,30 @@
 # frozen_string_literal: true
 
-# @api private
-# @since 0.2.0
-module Qonfig::DataSet::ClassBuilder
-  class << self
-    # @param hash [Hash]
-    # @return [Class<Qonfig::DataSet>]
-    #
+module Qonfig
+  class DataSet
     # @api private
     # @since 0.2.0
-    def build_from_hash(hash)
-      Class.new(Qonfig::DataSet).tap do |data_set_klass|
-        hash.each_pair do |key, value|
-          if value.is_a?(Hash)
-            sub_data_set_klass = build_from_hash(value)
+    module ClassBuilder
+      class << self
+        # @param hash [Hash]
+        # @return [Class<Qonfig::DataSet>]
+        #
+        # @see [Qonfig::DataSet]
+        # @see [Qonfig::DSL]
+        #
+        # @api private
+        # @since 0.2.0
+        def build_from_hash(hash)
+          Class.new(Qonfig::DataSet).tap do |data_set_klass|
+            hash.each_pair do |key, value|
+              if value.is_a?(Hash)
+                sub_data_set_klass = build_from_hash(value)
 
-            data_set_klass.setting(key) { compose sub_data_set_klass }
-          else
-            data_set_klass.setting key, value
+                data_set_klass.setting(key) { compose sub_data_set_klass }
+              else
+                data_set_klass.setting key, value
+              end
+            end
           end
         end
       end

--- a/lib/qonfig/data_set/class_builder.rb
+++ b/lib/qonfig/data_set/class_builder.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# @api private
+# @since 0.2.0
+module Qonfig::DataSet::ClassBuilder
+  class << self
+    # @param hash [Hash]
+    # @return [Class<Qonfig::DataSet>]
+    #
+    # @api private
+    # @since 0.2.0
+    def build_from_hash(hash)
+      Class.new(Qonfig::DataSet).tap do |data_set_klass|
+        hash.each_pair do |key, value|
+          if value.is_a?(Hash)
+            sub_data_set_klass = build_from_hash(value)
+
+            data_set_klass.setting(key) { compose sub_data_set_klass }
+          else
+            data_set_klass.setting key, value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/qonfig/data_set/class_builder.rb
+++ b/lib/qonfig/data_set/class_builder.rb
@@ -9,8 +9,8 @@ module Qonfig
         # @param hash [Hash]
         # @return [Class<Qonfig::DataSet>]
         #
-        # @see [Qonfig::DataSet]
-        # @see [Qonfig::DSL]
+        # @see Qonfig::DataSet
+        # @see Qonfig::DSL
         #
         # @api private
         # @since 0.2.0

--- a/lib/qonfig/dsl.rb
+++ b/lib/qonfig/dsl.rb
@@ -35,6 +35,9 @@ module Qonfig
     # @param nested_settings [Proc]
     # @return [void]
     #
+    # @see Qonfig::Commands::AddNestedOption
+    # @see Qonfig::Commands::AddOption
+    #
     # @api public
     # @since 0.1.0
     def setting(key, initial_value = nil, &nested_settings)
@@ -52,6 +55,8 @@ module Qonfig
     # @param data_set_klass [Class{Qonfig::DataSet}]
     # @return [void]
     #
+    # @see Qonfig::Comamnds::Compose
+    #
     # @api private
     # @sine 0.1.0
     def compose(data_set_klass)
@@ -61,6 +66,8 @@ module Qonfig
     # @param file_path [String]
     # @return [void]
     #
+    # @see Qonfig::Commands::LoadFromYAML
+    #
     # @api public
     # @since 0.2.0
     def load_from_yaml(file_path)
@@ -68,6 +75,8 @@ module Qonfig
     end
 
     # @return [void]
+    #
+    # @see Qonfig::Commands::LoadFromSelf
     #
     # @api public
     # @since 0.2.0

--- a/lib/qonfig/dsl.rb
+++ b/lib/qonfig/dsl.rb
@@ -67,6 +67,10 @@ module Qonfig
       commands << Qonfig::Commands::LoadFromYAML.new(file_path)
     end
 
+    # @return [void]
+    #
+    # @api public
+    # @since 0.2.0
     def load_from_self
       caller_location = caller(1, 1).first
       commands << Qonfig::Commands::LoadFromSelf.new(caller_location)

--- a/lib/qonfig/dsl.rb
+++ b/lib/qonfig/dsl.rb
@@ -66,5 +66,10 @@ module Qonfig
     def load_from_yaml(file_path)
       commands << Qonfig::Commands::LoadFromYAML.new(file_path)
     end
+
+    def load_from_self
+      caller_location = caller(1, 1).first
+      commands << Qonfig::Commands::LoadFromSelf.new(caller_location)
+    end
   end
 end

--- a/lib/qonfig/error.rb
+++ b/lib/qonfig/error.rb
@@ -29,4 +29,10 @@ module Qonfig
   # @api public
   # @since 0.2.0
   IncompatibleYAMLError = Class.new(Error)
+
+  # @see Qonfig::Commands::LoadFromSelf
+  #
+  # @api public
+  # @since 0.2.0
+  SelfDataNotFoundError = Class.new(Error)
 end

--- a/spec/features/load_from_self/with_hash_like_data_representation_spec.rb
+++ b/spec/features/load_from_self/with_hash_like_data_representation_spec.rb
@@ -4,29 +4,40 @@ describe 'Load from self (hash-like __END__ data representation)' do
   specify 'defines config object by self-contained __END__ yaml data' do
     class SelfDefinedConfig < Qonfig::DataSet
       load_from_self
+
+      setting :with_nesting do
+        load_from_self
+      end
     end
 
     SelfDefinedConfig.new.settings.tap do |conf|
-      expect(conf.database.user).to     eq('admin')
-      expect(conf.database.password).to eq('admin')
-      expect(conf.database.host).to     eq('1.2.3.4')
-      expect(conf.database.port).to     eq(666)
-      expect(conf.enable_api).to        eq(true)
+      expect(conf.secret_key).to eq('top-mega-secret')
+      expect(conf.api_host).to eq('super.puper-google.com')
+      expect(conf.connection_timeout.seconds).to eq(10)
+      expect(conf.connection_timeout.enabled).to eq(false)
 
-      expect(conf['database']['user']).to     eq('admin')
-      expect(conf['database']['password']).to eq('admin')
-      expect(conf['database']['host']).to     eq('1.2.3.4')
-      expect(conf['database']['port']).to     eq(666)
-      expect(conf[:enable_api]).to            eq(true)
+      expect(conf['secret_key']).to eq('top-mega-secret')
+      expect(conf['api_host']).to eq('super.puper-google.com')
+      expect(conf[:connection_timeout]['seconds']).to eq(10)
+      expect(conf[:connection_timeout]['enabled']).to eq(false)
+
+      expect(conf.with_nesting.secret_key).to eq('top-mega-secret')
+      expect(conf.with_nesting.api_host).to eq('super.puper-google.com')
+      expect(conf.with_nesting.connection_timeout.seconds).to eq(10)
+      expect(conf.with_nesting.connection_timeout.enabled).to eq(false)
+
+      expect(conf[:with_nesting]['secret_key']).to eq('top-mega-secret')
+      expect(conf[:with_nesting]['api_host']).to eq('super.puper-google.com')
+      expect(conf[:with_nesting][:connection_timeout]['seconds']).to eq(10)
+      expect(conf[:with_nesting][:connection_timeout]['enabled']).to eq(false)
     end
   end
 end
 
 __END__
 
-database:
-  user: admin
-  password: admin
-  host: 1.2.3.4
-  port: 666
-:enable_api: true
+secret_key: top-mega-secret
+api_host: super.puper-google.com
+:connection_timeout:
+   seconds: 10
+   enabled: false

--- a/spec/features/load_from_self/with_hash_like_data_representation_spec.rb
+++ b/spec/features/load_from_self/with_hash_like_data_representation_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+describe 'Load from self (hash-like __END__ data representation)' do
+  specify 'defines config object by self-contained __END__ yaml data' do
+    class SelfDefinedConfig < Qonfig::DataSet
+      load_from_self
+    end
+
+    SelfDefinedConfig.new.settings.tap do |conf|
+      expect(conf.database.user).to     eq('admin')
+      expect(conf.database.password).to eq('admin')
+      expect(conf.database.host).to     eq('1.2.3.4')
+      expect(conf.database.port).to     eq(666)
+      expect(conf.enable_api).to        eq(true)
+
+      expect(conf['database']['user']).to     eq('admin')
+      expect(conf['database']['password']).to eq('admin')
+      expect(conf['database']['host']).to     eq('1.2.3.4')
+      expect(conf['database']['port']).to     eq(666)
+      expect(conf[:enable_api]).to            eq(true)
+    end
+  end
+end
+
+__END__
+
+database:
+  user: admin
+  password: admin
+  host: 1.2.3.4
+  port: 666
+:enable_api: true

--- a/spec/features/load_from_self/with_non_hash_like_data_representation_spec.rb
+++ b/spec/features/load_from_self/with_non_hash_like_data_representation_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe 'Load from self (non-hash-like __END__ data representation)' do
+  specify 'fails when yaml data is not represented as a hash' do
+    class IncompatibleSelfDataConfig < Qonfig::DataSet
+      load_from_self
+    end
+
+    expect { IncompatibleSelfDataConfig.new }.to raise_error(Qonfig::IncompatibleYAMLError)
+  end
+end
+
+__END__
+
+- user
+- password
+- 123

--- a/spec/features/load_from_self/without_end_data_spec.rb
+++ b/spec/features/load_from_self/without_end_data_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe 'Load from self (without __END__ data)' do
+  specify 'fails when yaml data is not represented as a hash' do
+    class MissingSelfDataConfig < Qonfig::DataSet
+      load_from_self
+    end
+
+    expect { MissingSelfDataConfig.new }.to raise_error(Qonfig::SelfDataNotFoundError)
+  end
+end

--- a/spec/features/state_freeze_spec.rb
+++ b/spec/features/state_freeze_spec.rb
@@ -42,11 +42,9 @@ describe 'State freeze' do
     expect { frozen_config.reload! }.to raise_error(Qonfig::FrozenSettingsError)
 
     expect(frozen_config.to_h).to match(
-      {
-        api_mode_enabled: true,
-        api: { format: :json },
-        additionals: false
-      }
+      api_mode_enabled: true,
+      api: { format: :json },
+      additionals: false
     )
   end
 end


### PR DESCRIPTION
## load_from_self

`.load_from_self` allows you to load config definitions from the YAML instructions written in the file where your config class is described.

---

### API:

```ruby
class Config < Qonfig::DataSet  
  setting :clowd do
    load_from_self
  end
end

config = Config.new

config.settings.cloud.secret_key # => 'top-mega-secret'
config.settings.cloud.api_host # => 'super.puper-google.com'
config.settings.cloud.connection_timeout.seconds # => 10
config.settings.cloud.connection_timeout.enabled # => false

__END__

secret_key: top-mega-secret
api_host: super.puper-google.com
connection_timeout:
   seconds: 10
   enabled: false
```