### PR TITLE
[.freeze!] FrozenError as a superclass for Qonfig::FrozenSettingsError

### DIFF
--- a/lib/qonfig/error.rb
+++ b/lib/qonfig/error.rb
@@ -23,11 +23,13 @@ module Qonfig
   # @api public
   # @since 0.1.0
   FrozenSettingsError = begin
+    # :nocov:
     if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
       Class.new(::FrozenError)
     else
       Class.new(::RuntimeError)
     end
+    # :nocov:
   end
 
   # @see Qonfig::Commands::LoadFromYAML

--- a/lib/qonfig/error.rb
+++ b/lib/qonfig/error.rb
@@ -22,7 +22,7 @@ module Qonfig
   #
   # @api public
   # @since 0.1.0
-  FrozenSettingsError = Class.new(Error)
+  FrozenSettingsError = Class.new(FrozenError)
 
   # @see Qonfig::Commands::LoadFromYAML
   #

--- a/lib/qonfig/error.rb
+++ b/lib/qonfig/error.rb
@@ -22,7 +22,13 @@ module Qonfig
   #
   # @api public
   # @since 0.1.0
-  FrozenSettingsError = Class.new(FrozenError)
+  FrozenSettingsError = begin
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
+      Class.new(::FrozenError)
+    else
+      Class.new(::RuntimeError)
+    end
+  end
 
   # @see Qonfig::Commands::LoadFromYAML
   #

--- a/spec/features/state_freeze_spec.rb
+++ b/spec/features/state_freeze_spec.rb
@@ -33,9 +33,15 @@ describe 'State freeze' do
       expect { conf.api.format = :xml }.to        raise_error(Qonfig::FrozenSettingsError)
       expect { conf.additionals = true }.to       raise_error(Qonfig::FrozenSettingsError)
 
-      expect { conf.api_mode_enabled = false }.to raise_error(FrozenError)
-      expect { conf.api.format = :xml }.to        raise_error(FrozenError)
-      expect { conf.additionals = true }.to       raise_error(FrozenError)
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
+        expect { conf.api_mode_enabled = false }.to raise_error(::FrozenError)
+        expect { conf.api.format = :xml }.to        raise_error(::FrozenError)
+        expect { conf.additionals = true }.to       raise_error(::FrozenError)
+      else
+        expect { conf.api_mode_enabled = false }.to raise_error(::RuntimeError)
+        expect { conf.api.format = :xml }.to        raise_error(::RuntimeError)
+        expect { conf.additionals = true }.to       raise_error(::RuntimeError)
+      end
     end
 
     # cannot reload config object
@@ -44,7 +50,12 @@ describe 'State freeze' do
     end
 
     expect { frozen_config.reload! }.to raise_error(Qonfig::FrozenSettingsError)
-    expect { frozen_config.reload! }.to raise_error(FrozenError)
+
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
+      expect { frozen_config.reload! }.to raise_error(::FrozenError)
+    else
+      expect { frozen_config.reload! }.to raise_error(::RuntimeError)
+    end
 
     expect(frozen_config.to_h).to match(
       {

--- a/spec/features/state_freeze_spec.rb
+++ b/spec/features/state_freeze_spec.rb
@@ -30,8 +30,12 @@ describe 'State freeze' do
     # cannot modify config values
     frozen_config.configure do |conf|
       expect { conf.api_mode_enabled = false }.to raise_error(Qonfig::FrozenSettingsError)
-      expect { conf.api.format = :xml }.to raise_error(Qonfig::FrozenSettingsError)
-      expect { conf.additionals = true }.to raise_error(Qonfig::FrozenSettingsError)
+      expect { conf.api.format = :xml }.to        raise_error(Qonfig::FrozenSettingsError)
+      expect { conf.additionals = true }.to       raise_error(Qonfig::FrozenSettingsError)
+
+      expect { conf.api_mode_enabled = false }.to raise_error(FrozenError)
+      expect { conf.api.format = :xml }.to        raise_error(FrozenError)
+      expect { conf.additionals = true }.to       raise_error(FrozenError)
     end
 
     # cannot reload config object
@@ -40,6 +44,7 @@ describe 'State freeze' do
     end
 
     expect { frozen_config.reload! }.to raise_error(Qonfig::FrozenSettingsError)
+    expect { frozen_config.reload! }.to raise_error(FrozenError)
 
     expect(frozen_config.to_h).to match(
       {


### PR DESCRIPTION
See #7 (`.freeze!` part) (thx to [JelF](https://github.com/JelF))

---

Problem:

- [x] breaks `catch all Qonfig-related errors` feature (`rescue Qonfig::Error`).
  - useless, and `Qonfig::FrozenSettingsError` should be a subclass of `FrozenError` for ruby >= 2.5 and `RuntimeError` for ruby < 2.5. Developers are expecting this when `frozen restriction` of an object is violated.
- [x] breaks backward compatability (`FrozenError` introduced in `ruby 2.5`)
  - `Qonfig::FrozenSettingsError = Class.new(::RuntimeError)` (ruby < 2.5)
  - `Qonfig::FrozenSettingsError = Class.new(::FrozenError)` (ruby >= 2.5)
