### PR TITLE
HashWithIndifferentAccess-like behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ All notable changes to this project will be documented in this file.
 - Instant configuration via block `config = Config.new { |conf| <<your configuration code>> }`;
 - `.load_from_yaml` command - an ability to define config settings by loading them from a yaml file;
 - `.load_from_self` command - an ability to load config definitions form the YAML
-  instructions written in the file where the config class is defined;
+  instructions written in the file where the config class is defined (`__END__` section);
 - `#reload!` - an ability to reload config isntance after any config class changes and updates;
 - Support for ERB instructions in YAML;
-- Thread-safe implementation;
+- Support for `HashWithIndifferentAccess`-like behaviour;
+- Refactoring: thread-safe implementation;
 
 ### Changed
 - Superclass of `Qonfig::FrozenSettingsError` (it was `Qonfig::Error` before):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - `#reload!` - an ability to reload config isntance after any config class changes and updates;
 - Support for ERB instructions in YAML;
 - Support for `HashWithIndifferentAccess`-like behaviour;
-- Refactoring: thread-safe implementation;
+- Full thread-safe implementation;
 
 ### Changed
 - Superclass of `Qonfig::FrozenSettingsError` (it was `Qonfig::Error` before):
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Recoursive hash representation with deep nested `Qonfig::Settings` values (infinite loop);
+- Fixed re-assigning of options with nested options (losing the nested options
+  due to the instance configuration). Now it causes `Qonfig::AmbigousSettingValueError`.
 
 ## [0.1.0] - 2018-05-18
 - Release :)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file.
 - `.load_from_self` command - an ability to load config definitions form the YAML
   instructions written in the file where the config class is defined (`__END__` section);
 - `#reload!` - an ability to reload config isntance after any config class changes and updates;
-- `#dig` - an ability to fetch setting values with `Hash#dig` manner
-  (fails with `Qonfig::UnknownSettingError`when the required key does not exist);
+- `#dig` - an ability to fetch setting values in `Hash#dig` manner
+  (fails with `Qonfig::UnknownSettingError` when the required key does not exist);
 - Support for ERB instructions in YAML;
 - Support for `HashWithIndifferentAccess`-like behaviour;
 - Full thread-safe implementation;
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Recoursive hash representation with deep nested `Qonfig::Settings` values (infinite loop);
-- Fixed re-assigning of options with nested options (losing the nested options
+- Fixed re-assignment of the options with nested options (losing the nested options
   due to the instance configuration). Now it causes `Qonfig::AmbigousSettingValueError`.
 
 ## [0.1.0] - 2018-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 - `.load_from_self` command - an ability to load config definitions form the YAML
   instructions written in the file where the config class is defined (`__END__` section);
 - `#reload!` - an ability to reload config isntance after any config class changes and updates;
+- `#dig` - an ability to fetch setting values with `Hash#dig` manner
+  (fails with `Qonfig::UnknownSettingError`when the required key does not exist);
 - Support for ERB instructions in YAML;
 - Support for `HashWithIndifferentAccess`-like behaviour;
 - Full thread-safe implementation;

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ class Config < Qonfig::DataSet
   # nested setting
   setting :vendor_api do
     setting :host, 'app.service.com'
-    setting :port, 12345
   end
 
   setting :enable_graphql, false
@@ -51,7 +50,6 @@ class Config < Qonfig::DataSet
   # nested setting reopening
   setting :vendor_api do
     setting :user, 'test_user'
-    setting :password, 'test_password'
   end
 end
 
@@ -60,25 +58,19 @@ config = Config.new
 # get option value via method
 config.settings.project_id # => nil
 config.settings.vendor_api.host # => 'app.service.com'
-config.settings.vendor_api.port # => 12345
 config.settings.vendor_api.user # => 'test_user'
-config.settings.vendor_api.password # => 'test_password'
 config.settings.enable_graphql # => false
 
 # get option value via index (with indifferent access)
 config.settings[:project_id] # => nil
 config.settings[:vendor_api][:host] # => 'app.service.com'
-config.settings[:vendor_api][:port] # => 12345
 config.settings[:vendor_api][:user] # => 'test_user'
-config.settings[:vendor_api][:password] # => 'test_password'
 config.settings[:enable_graphql] # => false
 
 # get option value via index (with indifferent access)
 config.settings['project_id'] # => nil
 config.settings['vendor_api']['host'] # => 'app.service.com'
-config.settings['vendor_api']['port'] # => 12345
 config.settings['vendor_api']['user'] # => 'test_user'
-config.settings['vendor_api']['password'] # => 'test_password'
 config.settings['enable_graphql'] # => false
 
 # get option value directly via index (with indifferent access)
@@ -86,6 +78,10 @@ config['project_id'] # => nil
 config['enable_graphql'] # => false
 config[:project_id] # => nil
 config[:enable_graphql] # => false
+
+# get option value with Hash#dig manner (fails when the required key does not exist)
+config.dig(:vendor_api, :host) # => 'app.service.com' # (key exists)
+config.dig(:vendor_api, :port) # => Qonfig::UnknownSettingError # (key does not exist)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ require 'qonfig'
 - [Hash representation](#hash-representation)
 - [State freeze](#state-freeze)
 - [Reload](#reload)
-- [Load from YAML](#load-from-yaml)
+- [Load from YAML file](#load-from-yaml-file)
 - [Load from self](#load-from-self)
 
 ---
@@ -57,6 +57,7 @@ end
 
 config = Config.new
 
+# get option value via method
 config.settings.project_id # => nil
 config.settings.vendor_api.host # => 'app.service.com'
 config.settings.vendor_api.port # => 12345
@@ -64,12 +65,27 @@ config.settings.vendor_api.user # => 'test_user'
 config.settings.vendor_api.password # => 'test_password'
 config.settings.enable_graphql # => false
 
+# get option value via index (with indifferent access)
 config.settings[:project_id] # => nil
 config.settings[:vendor_api][:host] # => 'app.service.com'
 config.settings[:vendor_api][:port] # => 12345
 config.settings[:vendor_api][:user] # => 'test_user'
 config.settings[:vendor_api][:password] # => 'test_password'
 config.settings[:enable_graphql] # => false
+
+# get option value via index (with indifferent access)
+config.settings['project_id'] # => nil
+config.settings['vendor_api']['host'] # => 'app.service.com'
+config.settings['vendor_api']['port'] # => 12345
+config.settings['vendor_api']['user'] # => 'test_user'
+config.settings['vendor_api']['password'] # => 'test_password'
+config.settings['enable_graphql'] # => false
+
+# get option value directly via index (with indifferent access)
+config['project_id'] # => nil
+config['enable_graphql'] # => false
+config[:project_id] # => nil
+config[:enable_graphql] # => false
 ```
 
 ---
@@ -210,12 +226,12 @@ end
 Config.new.to_h
 
 {
-  serializers: {
-    json: { engine: :ok },
-    hash: { engine: :native },
+  "serializers": {
+    "json" => { "engine" => :ok },
+    "hash" => { "engine" => :native },
   },
-  adapter: { default: :memory_sync },
-  logger: #<Logger:0x4b0d79fc>
+  "adapter" => { "default" => :memory_sync },
+  "logger" => #<Logger:0x4b0d79fc>
 }
 ```
 
@@ -260,9 +276,9 @@ config.reload! do |conf|
   conf.enable_api = true # changed instantly
 end
 
-conf.settings.db.adapter # => 'mongoid'
-conf.settings.logger = # => #<Logger:0x00007ff9>
-config.enable_api # => true # value from instant change
+config.settings.db.adapter # => 'mongoid'
+config.settings.logger = # => #<Logger:0x00007ff9>
+config.settings.enable_api # => true # value from instant change
 ```
 
 ---
@@ -290,7 +306,7 @@ config.reload! # => Qonfig::FrozenSettingsError
 
 ---
 
-### Load from YAML
+### Load from YAML file
 
 ```yaml
 <!-- travis.yml -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ require 'qonfig'
 - [State freeze](#state-freeze)
 - [Reload](#reload)
 - [Load from YAML file](#load-from-yaml-file)
-- [Load from self](#load-from-self)
+- [Load from self](#load-from-self) (aka load from \_\_END\_\_)
 
 ---
 
@@ -61,13 +61,13 @@ config.settings.vendor_api.host # => 'app.service.com'
 config.settings.vendor_api.user # => 'test_user'
 config.settings.enable_graphql # => false
 
-# get option value via index (with indifferent access)
+# get option value via index (with indifferent (string / symbol / mixed) access)
 config.settings[:project_id] # => nil
 config.settings[:vendor_api][:host] # => 'app.service.com'
 config.settings[:vendor_api][:user] # => 'test_user'
 config.settings[:enable_graphql] # => false
 
-# get option value via index (with indifferent access)
+# get option value via index (with indifferent (string / symbol / mixed) access)
 config.settings['project_id'] # => nil
 config.settings['vendor_api']['host'] # => 'app.service.com'
 config.settings['vendor_api']['user'] # => 'test_user'
@@ -79,7 +79,7 @@ config['enable_graphql'] # => false
 config[:project_id] # => nil
 config[:enable_graphql] # => false
 
-# get option value with Hash#dig manner (fails when the required key does not exist)
+# get option value in Hash#dig manner (and fail when the required key does not exist)
 config.dig(:vendor_api, :host) # => 'app.service.com' # (key exists)
 config.dig(:vendor_api, :port) # => Qonfig::UnknownSettingError # (key does not exist)
 ```

--- a/lib/qonfig/data_set.rb
+++ b/lib/qonfig/data_set.rb
@@ -72,10 +72,19 @@ module Qonfig
     # @param setting_key [String, Symbol]
     # @return [Object]
     #
-    # @api private
+    # @api public
     # @since 0.2.0
     def [](setting_key)
       thread_safe_access { settings[setting_key] }
+    end
+
+    # @param keys [Array<String, Symbol>]
+    # @return [Object]
+    #
+    # @api public
+    # @since 0.2.0
+    def dig(*keys)
+      thread_safe_access { settings.__dig__(*keys) }
     end
 
     private
@@ -91,7 +100,7 @@ module Qonfig
     # @param configurations [Proc]
     # @return [void]
     #
-    # @api public
+    # @api private
     # @since 0.2.0
     def load!(&configurations)
       @settings = build_settings
@@ -101,7 +110,7 @@ module Qonfig
     # @param instructions [Proc]
     # @return [Object]
     #
-    # @api public
+    # @api private
     # @since 0.2.0
     def thread_safe_access(&instructions)
       @__access_lock__.synchronize(&instructions)
@@ -110,7 +119,7 @@ module Qonfig
     # @param instructions [Proc]
     # @return [Object]
     #
-    # @api public
+    # @api private
     # @since 0.2.0
     def thread_safe_definition(&instructions)
       @__definition_lock__.synchronize(&instructions)

--- a/lib/qonfig/data_set.rb
+++ b/lib/qonfig/data_set.rb
@@ -78,16 +78,6 @@ module Qonfig
       thread_safe_access { settings[setting_key] }
     end
 
-    # @param setting_key [String, Symbol]
-    # @param setting_value [Object]
-    # @return [Object]
-    #
-    # @api private
-    # @since 0.2.0
-    def []=(setting_key, setting_value)
-      thread_safe_access { settings[setting_key] = setting_value }
-    end
-
     private
 
     # @return [Qonfig::Settings]

--- a/lib/qonfig/data_set.rb
+++ b/lib/qonfig/data_set.rb
@@ -79,6 +79,7 @@ module Qonfig
     end
 
     # @param setting_key [String, Symbol]
+    # @param setting_value [Object]
     # @return [Object]
     #
     # @api private

--- a/lib/qonfig/data_set.rb
+++ b/lib/qonfig/data_set.rb
@@ -69,6 +69,24 @@ module Qonfig
     end
     alias_method :to_hash, :to_h
 
+    # @param setting_key [String, Symbol]
+    # @return [Object]
+    #
+    # @api private
+    # @since 0.2.0
+    def [](setting_key)
+      thread_safe_access { settings[setting_key] }
+    end
+
+    # @param setting_key [String, Symbol]
+    # @return [Object]
+    #
+    # @api private
+    # @since 0.2.0
+    def []=(setting_key, setting_value)
+      thread_safe_access { settings[setting_key] = setting_value }
+    end
+
     private
 
     # @return [Qonfig::Settings]

--- a/lib/qonfig/error.rb
+++ b/lib/qonfig/error.rb
@@ -21,6 +21,12 @@ module Qonfig
   # @see Qonfig::Settings
   #
   # @api public
+  # @since 0.2.0
+  AmbiguousSettingValueError = Class.new(Error)
+
+  # @see Qonfig::Settings
+  #
+  # @api public
   # @since 0.1.0
   FrozenSettingsError = begin # rubocop:disable Naming/ConstantName
     # :nocov:

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -32,6 +32,8 @@ module Qonfig
         end
         # :nocov:
 
+        key = __indifferently_accessable_option_key__(key)
+
         case
         when !__options__.key?(key)
           __options__[key] = value
@@ -66,6 +68,8 @@ module Qonfig
     # @since 0.1.0
     def [](key)
       __lock__.thread_safe_access do
+        key = __indifferently_accessable_option_key__(key)
+
         unless __options__.key?(key)
           raise Qonfig::UnknownSettingError, "Setting with <#{key}> key does not exist!"
         end
@@ -84,6 +88,8 @@ module Qonfig
     # @since 0.1.0
     def []=(key, value)
       __lock__.thread_safe_access do
+        key = __indifferently_accessable_option_key__(key)
+
         unless __options__.key?(key)
           raise Qonfig::UnknownSettingError, "Setting with <#{key}> key does not exist!"
         end
@@ -103,6 +109,7 @@ module Qonfig
     def __to_hash__
       __lock__.thread_safe_access { __build_hash_representation__ }
     end
+    alias_method :__to_h__, :__to_hash__
 
     # @param method_name [String, Symbol]
     # @param arguments [Array<Object>]
@@ -196,6 +203,15 @@ module Qonfig
       define_singleton_method("#{key}=") do |value|
         self.[]=(key, value)
       end unless __options__[key].is_a?(Qonfig::Settings)
+    end
+
+    # @param key [Symbol, String]
+    # @return [String]
+    #
+    # @api private
+    # @since 0.2.0
+    def __indifferently_accessable_option_key__(key)
+      key.to_s
     end
   end
 end

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Qonfig
+  # rubocop:disable Metrics/ClassLength
+
   # @api private
   # @since 0.1.0
   class Settings
@@ -187,7 +189,7 @@ module Qonfig
     #
     # @api private
     # @since 0.2.0
-    def __deep_access__(*keys, result: nil)
+    def __deep_access__(*keys)
       raise Qonfig::ArgumentError, 'Key list can not be empty' if keys.empty?
 
       result = __get_value__(keys.first)
@@ -199,7 +201,7 @@ module Qonfig
       when !result.is_a?(Qonfig::Settings)
         raise(Qonfig::UnknownSettingError, 'Setting with requred digging sequence does not exist!')
       when result.is_a?(Qonfig::Settings)
-        result.__dig__(*rest_keys, result: result)
+        result.__dig__(*rest_keys)
       end
     end
 
@@ -257,4 +259,6 @@ module Qonfig
       key.to_s
     end
   end
+
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -182,7 +182,7 @@ module Qonfig
     end
 
     # @param keys [Array<Symbol, String>]
-    # @param result [Object]
+    # @option result [Object]
     # @return [Object]
     #
     # @api private
@@ -253,8 +253,6 @@ module Qonfig
         raise Qonfig::ArgumentError, 'Setting key should be a symbol or a string'
       end
       # :nocov:
-
-      # TODO: defend from [] and []= key strings
 
       key.to_s
     end

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -61,15 +61,7 @@ module Qonfig
     # @api public
     # @since 0.1.0
     def [](key)
-      __lock__.thread_safe_access do
-        key = __indifferently_accessable_option_key__(key)
-
-        unless __options__.key?(key)
-          raise Qonfig::UnknownSettingError, "Setting with <#{key}> key does not exist!"
-        end
-
-        __options__[key]
-      end
+      __lock__.thread_safe_access { __get_value__(key) }
     end
 
     # @param key [String, Symbol]
@@ -81,23 +73,16 @@ module Qonfig
     # @api public
     # @since 0.1.0
     def []=(key, value)
-      __lock__.thread_safe_access do
-        key = __indifferently_accessable_option_key__(key)
+      __lock__.thread_safe_access { __set_value__(key, value) }
+    end
 
-        unless __options__.key?(key)
-          raise Qonfig::UnknownSettingError, "Setting with <#{key}> key does not exist!"
-        end
-
-        if __options__.frozen?
-          raise Qonfig::FrozenSettingsError, 'Can not modify frozen settings'
-        end
-
-        if __options__[key].is_a?(Qonfig::Settings)
-          raise Qonfig::AmbiguousSettingValueError, 'Can not redefine option with nested options'
-        end
-
-        __options__[key] = value
-      end
+    # @param keys [Array<String, Symbol>]
+    # @return [Object]
+    #
+    # @api private
+    # @since 0.2.0
+    def __dig__(*keys)
+      __lock__.thread_safe_access { __deep_access__(*keys) }
     end
 
     # @return [Hash]
@@ -157,6 +142,67 @@ module Qonfig
 
     private
 
+    # @param key [String, Symbol]
+    # @return [Object]
+    #
+    # @api private
+    # @since 0.2.0
+    def __get_value__(key)
+      key = __indifferently_accessable_option_key__(key)
+
+      unless __options__.key?(key)
+        raise Qonfig::UnknownSettingError, "Setting with <#{key}> key does not exist!"
+      end
+
+      __options__[key]
+    end
+
+    # @param key [String, Symbol]
+    # @param value [Object]
+    # @return [void]
+    #
+    # @api private
+    # @since 0.2.0
+    def __set_value__(key, value)
+      key = __indifferently_accessable_option_key__(key)
+
+      unless __options__.key?(key)
+        raise Qonfig::UnknownSettingError, "Setting with <#{key}> key does not exist!"
+      end
+
+      if __options__.frozen?
+        raise Qonfig::FrozenSettingsError, 'Can not modify frozen settings'
+      end
+
+      if __options__[key].is_a?(Qonfig::Settings)
+        raise Qonfig::AmbiguousSettingValueError, 'Can not redefine option with nested options'
+      end
+
+      __options__[key] = value
+    end
+
+    # @param keys [Array<Symbol, String>]
+    # @param result [Object]
+    # @return [Object]
+    #
+    # @api private
+    # @since 0.2.0
+    def __deep_access__(*keys, result: nil)
+      raise Qonfig::ArgumentError, 'Key list can not be empty' if keys.empty?
+
+      result = __get_value__(keys.first)
+      rest_keys = Array(keys[1..-1])
+
+      case
+      when rest_keys.empty?
+        result
+      when !result.is_a?(Qonfig::Settings)
+        raise(Qonfig::UnknownSettingError, 'Setting with requred digging sequence does not exist!')
+      when result.is_a?(Qonfig::Settings)
+        result.__dig__(*rest_keys, result: result)
+      end
+    end
+
     # @return [Qonfig::Settings::Lock]
     #
     # @api private
@@ -207,6 +253,8 @@ module Qonfig
         raise Qonfig::ArgumentError, 'Setting key should be a symbol or a string'
       end
       # :nocov:
+
+      # TODO: defend from [] and []= key strings
 
       key.to_s
     end

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -92,6 +92,10 @@ module Qonfig
           raise Qonfig::FrozenSettingsError, 'Can not modify frozen settings'
         end
 
+        if __options__[key].is_a?(Qonfig::Settings)
+          raise Qonfig::AmbiguousSettingValueError, 'Can not redefine option with nested options'
+        end
+
         __options__[key] = value
       end
     end
@@ -183,20 +187,13 @@ module Qonfig
     # @api private
     # @since 0.1.0
     def __define_accessor__(key)
-      begin
-        singleton_class.send(:undef_method, key)
-      rescue NameError
+      define_singleton_method(key) do
+        self.[](key)
       end
 
-      begin
-        singleton_class.send(:undef_method, "#{key}=")
-      rescue NameError
-      end
-
-      define_singleton_method(key) { self.[](key) }
       define_singleton_method("#{key}=") do |value|
         self.[]=(key, value)
-      end unless __options__[key].is_a?(Qonfig::Settings)
+      end
     end
 
     # @param key [Symbol, String]

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -26,12 +26,6 @@ module Qonfig
     # @since 0.1.0
     def __define_setting__(key, value)
       __lock__.thread_safe_definition do
-        # :nocov:
-        unless key.is_a?(Symbol) || key.is_a?(String)
-          raise Qonfig::ArgumentError, 'Setting key should be a symbol or a string'
-        end
-        # :nocov:
-
         key = __indifferently_accessable_option_key__(key)
 
         case
@@ -211,6 +205,12 @@ module Qonfig
     # @api private
     # @since 0.2.0
     def __indifferently_accessable_option_key__(key)
+      # :nocov:
+      unless key.is_a?(Symbol) || key.is_a?(String)
+        raise Qonfig::ArgumentError, 'Setting key should be a symbol or a string'
+      end
+      # :nocov:
+
       key.to_s
     end
   end

--- a/spec/features/composition_spec.rb
+++ b/spec/features/composition_spec.rb
@@ -74,19 +74,27 @@ describe 'Composition' do
 
     # hash representation
     expect(config.to_h).to match(
-      db: {
-        username: 'kek',
-        password: 'pek',
-        connection: { address: 'google.com', port: 12_345 }
+      'db' => {
+        'username' => 'kek',
+        'password' => 'pek',
+        'connection' => {
+          'address' => 'google.com',
+          'port' => 12_345
+        }
       },
-      port: 8080,
-      host: '0.0.0.0',
-      enable_middlewares: true,
-      limits: { withdraw: 1_000_000, deposit: 3_000_000 },
-      api: {
-        version: '0.1.0',
-        header: 'app.vendor',
-        strategy: { format: :json }
+      'port' => 8080,
+      'host' => '0.0.0.0',
+      'enable_middlewares' => true,
+      'limits' => {
+        'withdraw' => 1_000_000,
+        'deposit' => 3_000_000
+      },
+      'api' => {
+        'version' => '0.1.0',
+        'header' => 'app.vendor',
+        'strategy' => {
+          'format' => :json
+        }
       }
     )
 
@@ -135,19 +143,27 @@ describe 'Composition' do
     end
 
     expect(config.to_h).to match(
-      db: {
-        username: 'che',
-        password: 'burek',
-        connection: { address: 'db.google.com', port: 666 }
+      'db' => {
+        'username' => 'che',
+        'password' => 'burek',
+        'connection' => {
+          'address' => 'db.google.com',
+          'port' => 666
+        }
       },
-      port: 8081,
-      host: 'app.google.com',
-      enable_middlewares: false,
-      limits: { withdraw: 0, deposit: 1_000 },
-      api: {
-        version: '0.2.0',
-        header: 'app.super.vendor',
-        strategy: { format: :xml }
+      'port' => 8081,
+      'host' => 'app.google.com',
+      'enable_middlewares' => false,
+      'limits' => {
+        'withdraw' => 0,
+        'deposit' => 1_000
+      },
+      'api' => {
+        'version' => '0.2.0',
+        'header' => 'app.super.vendor',
+        'strategy' => {
+          'format' => :xml
+        }
       }
     )
   end

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -245,4 +245,30 @@ describe 'Config definition' do
     expect(config['database'][:hostname]).to eq('google.com')
     expect(config[:database]['hostname']).to eq('google.com')
   end
+
+  specify 'causes an error when assigning a setting value to an option with nested options' do
+    class WithNestedOptionsConfig < Qonfig::DataSet
+      setting :database do
+        setting :hostname, 'localhost'
+      end
+    end
+
+    config = WithNestedOptionsConfig.new
+
+    expect do
+      config.configure { |conf| conf.database = double }
+    end.to raise_error(Qonfig::AmbiguousSettingValueError)
+
+    expect do
+      config.configure { |conf| conf[:database] = double }
+    end.to raise_error(Qonfig::AmbiguousSettingValueError)
+
+    expect do
+      config.configure { |conf| conf[:database][:hostname] = double}
+    end.not_to raise_error
+
+    expect do
+      config.configure { |conf| conf.database.hostname = double }
+    end.not_to raise_error
+  end
 end

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -246,7 +246,8 @@ describe 'Config definition' do
     expect(config[:database]['hostname']).to eq('google.com')
   end
 
-  specify 'causes an error when assigning a setting value to an option with nested options' do
+  specify 'causes an error when tries to assign a setting value to an option ' \
+          'which already have another nested options' do
     class WithNestedOptionsConfig < Qonfig::DataSet
       setting :database do
         setting :hostname, 'localhost'

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -271,4 +271,44 @@ describe 'Config definition' do
       config.configure { |conf| conf.database.hostname = double }
     end.not_to raise_error
   end
+
+  specify '#dig functionality' do
+    class DiggingConfig < Qonfig::DataSet
+      setting :db do
+        setting :creds do
+          setting :user, 'D@iVeR'
+          setting :password, 'test123'
+          setting :data, { test: false }
+        end
+      end
+    end
+
+    config = DiggingConfig.new
+
+    # acces to a value
+    expect(config.dig(:db, :creds, :user)).to eq('D@iVeR')
+    expect(config.dig('db', :creds, 'password')).to eq('test123')
+    expect(config.dig('db', 'creds', 'data')).to match(test: false)
+
+    # access to the settings
+    expect(config.dig(:db, :creds)).to be_a(Qonfig::Settings)
+    expect(config.dig(:db)).to be_a(Qonfig::Settings)
+
+    # try to dig into the hash value (setting with a hash value)
+    expect { config.dig(:db, :creds, :user, :test) }.to raise_error(Qonfig::UnknownSettingError)
+
+    # dig with empty key lists
+    expect { config.dig(*[]) }.to raise_error(Qonfig::ArgumentError)
+    expect { config.dig }.to raise_error(Qonfig::ArgumentError)
+
+    # dig into unexistent option
+    expect do
+      config.dig(:db, :creds, :session)
+    end.to raise_error(Qonfig::UnknownSettingError)
+
+    # dig into unexistent option
+    expect do
+      config.dig(:a, :b, :c, :d)
+    end.to raise_error(Qonfig::UnknownSettingError)
+  end
 end

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -59,11 +59,20 @@ describe 'Config definition' do
 
     # hash representation
     expect(config.to_h).to match(
-      serializers: { json: :native, xml: :native },
-      defaults: nil,
-      shared: { convert: false },
-      mutations: { action: { query: nil } },
-      steps: 22
+      'serializers' => {
+        'json' => :native,
+        'xml' => :native
+      },
+      'defaults' => nil,
+      'shared' => {
+        'convert' => false
+      },
+      'mutations' => {
+        'action' => {
+          'query' => nil
+        }
+      },
+      'steps' => 22
     )
 
     # configuration via block (classic style)
@@ -151,11 +160,20 @@ describe 'Config definition' do
 
     # hash representation
     expect(config.to_h).to match(
-      serializers: { json: :native, xml: :native },
-      defaults: nil,
-      shared: { convert: false },
-      mutations: { action: { query: 'delete' } },
-      steps: 0
+      'serializers' => {
+        'json' => :native,
+        'xml' => :native
+      },
+      'defaults' => nil,
+      'shared' => {
+        'convert' => false
+      },
+      'mutations' => {
+        'action' => {
+          'query' => 'delete'
+        }
+      },
+      'steps' => 0
     )
   end
 
@@ -172,5 +190,59 @@ describe 'Config definition' do
         setting 'b'
       end
     end.not_to raise_error
+  end
+
+  specify 'indifferently accessable options (directly via index; via string / via symbol)' do
+    class IndifferentlyAccessableConfig < Qonfig::DataSet
+      setting :project_id, 10
+    end
+
+    class AnotherIndifferentlyAccessableConfig < Qonfig::DataSet
+      compose IndifferentlyAccessableConfig
+
+      setting 'database' do
+        setting :hostname, 'localhost'
+      end
+    end
+
+    config = AnotherIndifferentlyAccessableConfig.new
+
+    # indifferent access via string / via symbol
+    expect(config.settings[:project_id]).to eq(10)
+    expect(config.settings['project_id']).to eq(10)
+    expect(config.settings[:database][:hostname]).to eq('localhost')
+    expect(config.settings['database']['hostname']).to eq('localhost')
+    expect(config.settings['database'][:hostname]).to eq('localhost')
+    expect(config.settings[:database]['hostname']).to eq('localhost')
+
+    # direct access via [] on the config object
+    expect(config[:project_id]).to eq(10)
+    expect(config['project_id']).to eq(10)
+    expect(config[:database][:hostname]).to eq('localhost')
+    expect(config['database']['hostname']).to eq('localhost')
+    expect(config['database'][:hostname]).to eq('localhost')
+    expect(config[:database]['hostname']).to eq('localhost')
+
+    # instant configuration with indifferently accessable options
+    config.configure do |conf|
+      conf['project_id'] = 1
+      conf[:database]['hostname'] = 'google.com'
+    end
+
+    # indifferent access via string / via symbol
+    expect(config.settings[:project_id]).to eq(1)
+    expect(config.settings['project_id']).to eq(1)
+    expect(config.settings[:database][:hostname]).to eq('google.com')
+    expect(config.settings['database']['hostname']).to eq('google.com')
+    expect(config.settings['database'][:hostname]).to eq('google.com')
+    expect(config.settings[:database]['hostname']).to eq('google.com')
+
+    # direct access via [] on the config object
+    expect(config[:project_id]).to eq(1)
+    expect(config['project_id']).to eq(1)
+    expect(config[:database][:hostname]).to eq('google.com')
+    expect(config['database']['hostname']).to eq('google.com')
+    expect(config['database'][:hostname]).to eq('google.com')
+    expect(config[:database]['hostname']).to eq('google.com')
   end
 end

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -265,7 +265,7 @@ describe 'Config definition' do
     end.to raise_error(Qonfig::AmbiguousSettingValueError)
 
     expect do
-      config.configure { |conf| conf[:database][:hostname] = double}
+      config.configure { |conf| conf[:database][:hostname] = double }
     end.not_to raise_error
 
     expect do
@@ -279,7 +279,7 @@ describe 'Config definition' do
         setting :creds do
           setting :user, 'D@iVeR'
           setting :password, 'test123'
-          setting :data, { test: false }
+          setting :data, test: false
         end
       end
     end
@@ -298,9 +298,11 @@ describe 'Config definition' do
     # try to dig into the hash value (setting with a hash value)
     expect { config.dig(:db, :creds, :user, :test) }.to raise_error(Qonfig::UnknownSettingError)
 
+    # rubocop:disable Lint/UnneededSplatExpansion
     # dig with empty key lists
     expect { config.dig(*[]) }.to raise_error(Qonfig::ArgumentError)
     expect { config.dig }.to raise_error(Qonfig::ArgumentError)
+    # rubocop:enable Lint/UnneededSplatExpansion
 
     # dig into unexistent option
     expect do

--- a/spec/features/inheritance_spec.rb
+++ b/spec/features/inheritance_spec.rb
@@ -60,14 +60,14 @@ describe 'Inheritance' do
 
     # hash representation
     expect(client_config.to_h).to match(
-      google_api: {
-        client_token: 'client-test-google-api',
-        token: 'test-google-api'
+      'google_api' => {
+        'client_token' => 'client-test-google-api',
+        'token' => 'test-google-api'
       },
-      defaults: nil,
-      admin_access_required: false,
-      version: '0.1.0',
-      unkown_data: true
+      'defaults' => nil,
+      'admin_access_required' => false,
+      'version' => '0.1.0',
+      'unkown_data' => true
     )
 
     # reconfigure
@@ -97,14 +97,14 @@ describe 'Inheritance' do
     end
 
     expect(client_config.to_h).to match(
-      google_api: {
-        client_token: 'none',
-        token: 'anti-hype'
+      'google_api' => {
+        'client_token' => 'none',
+        'token' => 'anti-hype'
       },
-      defaults: { a: 1 },
-      admin_access_required: true,
-      version: '0.2.0',
-      unkown_data: nil
+      'defaults' => { a: 1 },
+      'admin_access_required' => true,
+      'version' => '0.2.0',
+      'unkown_data' => nil
     )
   end
 end

--- a/spec/features/state_freeze_spec.rb
+++ b/spec/features/state_freeze_spec.rb
@@ -58,9 +58,11 @@ describe 'State freeze' do
     end
 
     expect(frozen_config.to_h).to match(
-      api_mode_enabled: true,
-      api: { format: :json },
-      additionals: false
+      'api_mode_enabled' => true,
+      'api' => {
+        'format' => :json
+      },
+      'additionals' => false
     )
   end
 end


### PR DESCRIPTION
Reader API:

```ruby
# index access through anything: string / symbol / mixing
config.settings[:database][:user]
config.settings['database']['user']
config.settings[:database][:user]
config.settings['database']['user']

# direct index access
config['database'][:user]
config[:database]['user']
```

---

Configuration API:

```ruby
config.configure do |conf|
  conf['database']['user'] = '0exp'
  conf[:database][:user] = '0exp'
  # ... and etc
end
```

---

`Hash#dig`-like behaviour (fails when a setting with required digging key does not exist)

```ruby
config.dig(:database, :user) # => '0exp'
config.dig(:database, :password) #> Qonfig::UnknownSettingError
```