### PR TITLE
Settings as Predicates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,9 @@ Lint/HandleExceptions:
 Metrics/MethodLength:
   Max: 20
 
+Style/DoubleNegation:
+  Enabled: false
+
 Style/EmptyCaseCondition:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes to this project will be documented in this file.
 - `#reload!` - an ability to reload config isntance after any config class changes and updates;
 - `#dig` - an ability to fetch setting values in `Hash#dig` manner
   (fails with `Qonfig::UnknownSettingError` when the required key does not exist);
+- Settings as Predicates - an ability to check the boolean nature of the config option by appending
+  the question mark symbol (`?`) at the end of option name:
+  `nil` and `false` returns `false`, others - returns `true`. Examples:
+  - `config.settings.database.user # => nil`;
+  - `config.settings.database.user? # => false`;
+  - `config.settings.database.host # => 'google.com'`;
+  - `config.settings.database.host? # => true`;
 - Support for ERB instructions in YAML;
 - Support for `HashWithIndifferentAccess`-like behaviour;
 - Full thread-safe implementation;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
     - `config.settings.database.user? # => false`;
     - `config.settings.database.host # => 'google.com'`;
     - `config.settings.database.host? # => true`;
-    - `config.settings.database? # => Qonfig::UnknownSettingError`
+    - `config.settings.database? # => true (setting with nested option (setting root))`
 - Support for ERB instructions in YAML;
 - Support for `HashWithIndifferentAccess`-like behaviour;
 - Full thread-safe implementation;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,17 @@ All notable changes to this project will be documented in this file.
 - `#reload!` - an ability to reload config isntance after any config class changes and updates;
 - `#dig` - an ability to fetch setting values in `Hash#dig` manner
   (fails with `Qonfig::UnknownSettingError` when the required key does not exist);
-- Settings as Predicates - an ability to check the boolean nature of the config option by appending
-  the question mark symbol (`?`) at the end of option name:
-  `nil` and `false` returns `false`, others - returns `true`. Examples:
-  - `config.settings.database.user # => nil`;
-  - `config.settings.database.user? # => false`;
-  - `config.settings.database.host # => 'google.com'`;
-  - `config.settings.database.host? # => true`;
+- Settings as Predicates - an ability to check the boolean nature of the config setting by appending
+  the question mark symbol (`?`) at the end of setting name:
+  - `nil` and `false` setting values indicates `false`;
+  - other setting values indicates `true`;
+  - setting roots does not have the predicate form;
+  - examples:
+    - `config.settings.database.user # => nil`;
+    - `config.settings.database.user? # => false`;
+    - `config.settings.database.host # => 'google.com'`;
+    - `config.settings.database.host? # => true`;
+    - `config.settings.database? # => Qonfig::UnknownSettingError`
 - Support for ERB instructions in YAML;
 - Support for `HashWithIndifferentAccess`-like behaviour;
 - Full thread-safe implementation;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
   the question mark symbol (`?`) at the end of setting name:
   - `nil` and `false` setting values indicates `false`;
   - other setting values indicates `true`;
-  - setting roots does not have the predicate form;
+  - setting roots always returns `true`;
   - examples:
     - `config.settings.database.user # => nil`;
     - `config.settings.database.user? # => false`;

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ require 'qonfig'
 
 - [Definition and Access](#definition-and-access)
 - [Configuration](#configuration)
+- [Settings as Predicates](#settings-as-predicates)
 - [Inheritance](#inheritance)
 - [Composition](#composition)
 - [Hash representation](#hash-representation)
@@ -127,6 +128,49 @@ config = Config.new do |conf|
   conf.geo_api.provider = :amazon_maps
   conf.testing.engine = :crypto_test
 end
+```
+
+---
+
+### Settings as Predicates
+
+- `nil` and `false` option values indicates `false`;
+- other option values indicates `true`;
+- parent options does not have the predicate form;
+
+```ruby
+class Config < Qonfig::DataSet
+  setting :database do
+    setting :user
+    setting :host, 'google.com'
+
+    setting :engine do
+      setting :driver, 'postgres'
+    end
+  end
+end
+
+config = Config.new
+
+# predicates
+config.settings.database.user? # => false (nil => false)
+config.settings.database.host? # => true ('google.com' => true)
+config.settings.database.engine.driver? # => true ('postgres' => true)
+
+# parent options does not have a predicate form
+config.settings.database? # => Qonfig::UnknownSettingError
+config.settings.database.engine? # => Qonfing::UnknownSettingError
+
+config.configure do |conf|
+  conf.database.user = '0exp'
+  conf.database.host = false
+  conf.database.engine.driver = true
+end
+
+# predicates
+config.settings.database.user? # => true ('0exp' => true)
+config.settings.database.host? # => false (false => false)
+config.settings.database.engine.driver # => true (true => true)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ require 'qonfig'
 
 - [Definition and Access](#definition-and-access)
 - [Configuration](#configuration)
-- [Settings as Predicates](#settings-as-predicates)
 - [Inheritance](#inheritance)
 - [Composition](#composition)
 - [Hash representation](#hash-representation)
 - [State freeze](#state-freeze)
 - [Reload](#reload)
+- [Settings as Predicates](#settings-as-predicates)
 - [Load from YAML file](#load-from-yaml-file)
 - [Load from self](#load-from-self) (aka load from \_\_END\_\_)
 
@@ -128,50 +128,6 @@ config = Config.new do |conf|
   conf.geo_api.provider = :amazon_maps
   conf.testing.engine = :crypto_test
 end
-```
-
----
-
-### Settings as Predicates
-
-- predicate form: `?` at the end of setting name;
-- `nil` and `false` setting values indicates `false`;
-- other setting values indicates `true`;
-- setting roots does not have the predicate form;
-
-```ruby
-class Config < Qonfig::DataSet
-  setting :database do
-    setting :user
-    setting :host, 'google.com'
-
-    setting :engine do
-      setting :driver, 'postgres'
-    end
-  end
-end
-
-config = Config.new
-
-# predicates
-config.settings.database.user? # => false (nil => false)
-config.settings.database.host? # => true ('google.com' => true)
-config.settings.database.engine.driver? # => true ('postgres' => true)
-
-# setting roots does not have the predicate form
-config.settings.database? # => Qonfig::UnknownSettingError
-config.settings.database.engine? # => Qonfing::UnknownSettingError
-
-config.configure do |conf|
-  conf.database.user = '0exp'
-  conf.database.host = false
-  conf.database.engine.driver = true
-end
-
-# predicates
-config.settings.database.user? # => true ('0exp' => true)
-config.settings.database.host? # => false (false => false)
-config.settings.database.engine.driver? # => true (true => true)
 ```
 
 ---
@@ -343,6 +299,50 @@ config.settings.worker = :que # => Qonfig::FrozenSettingsError
 config.settings.db.adapter = 'mongoid' # => Qonfig::FrozenSettingsError
 
 config.reload! # => Qonfig::FrozenSettingsError
+```
+
+---
+
+### Settings as Predicates
+
+- predicate form: `?` at the end of setting name;
+- `nil` and `false` setting values indicates `false`;
+- other setting values indicates `true`;
+- setting roots always returns `true`;
+
+```ruby
+class Config < Qonfig::DataSet
+  setting :database do
+    setting :user
+    setting :host, 'google.com'
+
+    setting :engine do
+      setting :driver, 'postgres'
+    end
+  end
+end
+
+config = Config.new
+
+# predicates
+config.settings.database.user? # => false (nil => false)
+config.settings.database.host? # => true ('google.com' => true)
+config.settings.database.engine.driver? # => true ('postgres' => true)
+
+# setting roots always returns true
+config.settings.database? # => true
+config.settings.database.engine? # => ture
+
+config.configure do |conf|
+  conf.database.user = '0exp'
+  conf.database.host = false
+  conf.database.engine.driver = true
+end
+
+# predicates
+config.settings.database.user? # => true ('0exp' => true)
+config.settings.database.host? # => false (false => false)
+config.settings.database.engine.driver? # => true (true => true)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -134,9 +134,10 @@ end
 
 ### Settings as Predicates
 
-- `nil` and `false` option values indicates `false`;
-- other option values indicates `true`;
-- parent options does not have the predicate form;
+- predicate form: `?` at the end of setting name;
+- `nil` and `false` setting values indicates `false`;
+- other setting values indicates `true`;
+- setting roots does not have the predicate form;
 
 ```ruby
 class Config < Qonfig::DataSet
@@ -157,7 +158,7 @@ config.settings.database.user? # => false (nil => false)
 config.settings.database.host? # => true ('google.com' => true)
 config.settings.database.engine.driver? # => true ('postgres' => true)
 
-# parent options does not have a predicate form
+# setting roots does not have the predicate form
 config.settings.database? # => Qonfig::UnknownSettingError
 config.settings.database.engine? # => Qonfing::UnknownSettingError
 
@@ -170,7 +171,7 @@ end
 # predicates
 config.settings.database.user? # => true ('0exp' => true)
 config.settings.database.host? # => false (false => false)
-config.settings.database.engine.driver # => true (true => true)
+config.settings.database.engine.driver? # => true (true => true)
 ```
 
 ---

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -234,7 +234,22 @@ module Qonfig
     #
     # @api private
     # @since 0.1.0
-    def __define_accessor__(key)
+    def __define_accessor__(key) # rubocop:disable Metrics/MethodLength
+      begin
+        singleton_class.send(:undef_method, key)
+      rescue NameError
+      end
+
+      begin
+        singleton_class.send(:undef_method, "#{key}=")
+      rescue NameError
+      end
+
+      begin
+        singleton_class.send(:undef_method, "#{key}?")
+      rescue NameError
+      end
+
       define_singleton_method(key) do
         self.[](key)
       end
@@ -242,6 +257,10 @@ module Qonfig
       define_singleton_method("#{key}=") do |value|
         self.[]=(key, value)
       end
+
+      define_singleton_method("#{key}?") do
+        !!self.[](key)
+      end unless __get_value__(key).is_a?(Qonfig::Settings)
     end
 
     # @param key [Symbol, String]

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -234,7 +234,7 @@ module Qonfig
     #
     # @api private
     # @since 0.1.0
-    def __define_accessor__(key) # rubocop:disable Metrics/MethodLength
+    def __define_accessor__(key)
       define_singleton_method(key) do
         self.[](key)
       end

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -199,7 +199,7 @@ module Qonfig
       when rest_keys.empty?
         result
       when !result.is_a?(Qonfig::Settings)
-        raise(Qonfig::UnknownSettingError, 'Setting with requred digging sequence does not exist!')
+        raise(Qonfig::UnknownSettingError, 'Setting with required digging sequence does not exist!')
       when result.is_a?(Qonfig::Settings)
         result.__dig__(*rest_keys)
       end
@@ -235,21 +235,6 @@ module Qonfig
     # @api private
     # @since 0.1.0
     def __define_accessor__(key) # rubocop:disable Metrics/MethodLength
-      begin
-        singleton_class.send(:undef_method, key)
-      rescue NameError
-      end
-
-      begin
-        singleton_class.send(:undef_method, "#{key}=")
-      rescue NameError
-      end
-
-      begin
-        singleton_class.send(:undef_method, "#{key}?")
-      rescue NameError
-      end
-
       define_singleton_method(key) do
         self.[](key)
       end
@@ -260,7 +245,7 @@ module Qonfig
 
       define_singleton_method("#{key}?") do
         !!self.[](key)
-      end unless __get_value__(key).is_a?(Qonfig::Settings)
+      end
     end
 
     # @param key [Symbol, String]

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -331,8 +331,8 @@ describe 'Config definition' do
     expect(config.settings.database.user?).to eq(false)
     expect(config.settings.database.host?).to eq(true)
     expect(config.settings.enable_mocks?).to eq(true)
-    # setting roots does not have the predicate form
-    expect { config.settings.database? }.to raise_error(Qonfig::UnknownSettingError)
+    # setting roots always returns true
+    expect(config.settings.database?).to eq(true)
 
     # reconfigure and check again
     config.configure do |conf|
@@ -345,7 +345,17 @@ describe 'Config definition' do
     expect(config.settings.database.user?).to eq(true)
     expect(config.settings.database.host?).to eq(false)
     expect(config.settings.enable_mocks?).to eq(false)
-    # setting roots does not have the predicate form
-    expect { config.settings.database? }.to raise_error(Qonfig::UnknownSettingError)
+    # setting roots always returns true
+    expect(config.settings.database?).to eq(true)
+
+    # clear all options
+    config.configure do |conf|
+      conf.database.user = nil
+      conf.database.host = nil
+      conf.enable_mocks = nil
+    end
+
+    # setting roots always returns true
+    expect(config.settings.database?).to eq(true)
   end
 end

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -331,7 +331,7 @@ describe 'Config definition' do
     expect(config.settings.database.user?).to eq(false)
     expect(config.settings.database.host?).to eq(true)
     expect(config.settings.enable_mocks?).to eq(true)
-    # parent options does not have the predicate form
+    # setting roots does not have the predicate form
     expect { config.settings.database? }.to raise_error(Qonfig::UnknownSettingError)
 
     # reconfigure and check again
@@ -345,7 +345,7 @@ describe 'Config definition' do
     expect(config.settings.database.user?).to eq(true)
     expect(config.settings.database.host?).to eq(false)
     expect(config.settings.enable_mocks?).to eq(false)
-    # parent options does not have the predicate form
+    # setting roots does not have the predicate form
     expect { config.settings.database? }.to raise_error(Qonfig::UnknownSettingError)
   end
 end

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -314,4 +314,38 @@ describe 'Config definition' do
       config.dig(:a, :b, :c, :d)
     end.to raise_error(Qonfig::UnknownSettingError)
   end
+
+  specify 'settings as predicates: boolean nature of the option value' do
+    class BooleanCheckConfig < Qonfig::DataSet
+      setting :database do
+        setting :user
+        setting :host, 'google.com'
+      end
+
+      setting :enable_mocks, true
+    end
+
+    config = BooleanCheckConfig.new
+
+    # predicats
+    expect(config.settings.database.user?).to eq(false)
+    expect(config.settings.database.host?).to eq(true)
+    expect(config.settings.enable_mocks?).to eq(true)
+    # parent options does not have the predicate form
+    expect { config.settings.database? }.to raise_error(Qonfig::UnknownSettingError)
+
+    # reconfigure and check again
+    config.configure do |conf|
+      conf.database.user = 'D@iVeR'
+      conf.database.host = nil
+      conf.enable_mocks = false
+    end
+
+    # predicates
+    expect(config.settings.database.user?).to eq(true)
+    expect(config.settings.database.host?).to eq(false)
+    expect(config.settings.enable_mocks?).to eq(false)
+    # parent options does not have the predicate form
+    expect { config.settings.database? }.to raise_error(Qonfig::UnknownSettingError)
+  end
 end


### PR DESCRIPTION
API:

- predicate form: `?` at the end of the setting name;
- `nil` and `false` setting values indicates `false`;
- other setting values indicates `true`;
- setting roots always returns `true`;

```ruby
class Config < Qonfig::DataSet
  setting :database do
    setting :user
    setting :host, 'google.com'

    setting :engine do
      setting :driver, 'postgres'
    end
  end
end

config = Config.new

# predicates
config.settings.database.user? # => false (nil => false)
config.settings.database.host? # => true ('google.com' => true)
config.settings.database.engine.driver? # => true ('postgres' => true)

# setting roots always returns true
config.settings.database? # => true
config.settings.database.engine? # => true

config.configure do |conf|
  conf.database.user = '0exp'
  conf.database.host = false
  conf.database.engine.driver = true
end

# predicates
config.settings.database.user? # => true ('0exp' => true)
config.settings.database.host? # => false (false => false)
config.settings.database.engine.driver? # => true (true => true)
```
