### PR TITLE
[load_from_env] - an ability to load config definitions from ENV (global var)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,8 +73,17 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Enabled: false
 
+Style/MultilineBlockChain:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 19
+
+Metrics/CyclomaticComplexity:
+  Max: 7
+
+Style/ClassAndModuleChildren:
+  Enabled: false
 
 Lint/UnderscorePrefixedVariableName:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Instant configuration via block `config = Config.new { |conf| <<your configuration code>> }`;
+- `.load_from_env` command - an ability to define config settings by loading them from ENV variable;
 - `.load_from_yaml` command - an ability to define config settings by loading them from a yaml file;
 - `.load_from_self` command - an ability to load config definitions form the YAML
   instructions written in the file where the config class is defined (`__END__` section);

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ require 'qonfig'
 - [Settings as Predicates](#settings-as-predicates)
 - [Load from YAML file](#load-from-yaml-file)
 - [Load from self](#load-from-self) (aka load from \_\_END\_\_)
+- [Load from ENV](#load-from-env)
 
 ---
 
@@ -432,6 +433,52 @@ api_host: super.puper-google.com
 connection_timeout:
    seconds: 10
    enabled: false
+```
+
+---
+
+### Load from ENV
+
+- `:convert_values` (`false` by default):
+  - `'t'`, `'T'`, `'true'`, `'TRUE'` - covnerts to `true`;
+  - `'f'`, `'F'`, `'false'`, `'FALSE'` - covnerts to `false`;
+  - `1`, `23` and etc - to `Integer`;
+  - `1.25`, `0.26` and etc - to `Float`;
+- `:prefix` - load ENV variables which names starts with a prefix:
+  - `nil` (by default) - empty prefix;
+  - `Regexp` - names that match the regexp pattern;
+  - `String` - names which starts with a passed string;
+
+```ruby
+# some env variables
+ENV['QONFIG_SETTINGS'] = 'true'
+ENV['QONFIG_TIMEOUT'] = '0'
+ENV['QONFIG_SPECS'] = 'none'
+ENV['RUN_CI'] = '1'
+
+class Config < Qonfig::DataSet
+  # nested (and customized)
+  setting :qonfig do
+    load_from_env convert_values: true, prefix: 'QONFIG' # or /\Aqonfig.*\z/i
+  end
+
+  # on the root (with defaults)
+  load_from_env
+end
+
+config = Config.new
+
+# customized
+config['qonfig']['QONFIG_SETTINGS'] # => true ('true' => true)
+config['qonfig']['QONFIG_TIMEOUT'] # => 0 ('0' => 0)
+config['qonfig']['QONFIG_SPECS'] # => 'none'
+config['qonfig']['RUN_CI'] # => Qonfig::UnknownSettingError
+
+# default
+config['QONFIG_SETTINGS'] # => 'true'
+config['QONFIG_TIMEOUT'] # => '0'
+conifg['QONFIG_SPECS'] # => 'none'
+config['RUN_CI'] # => '1'
 ```
 
 ---

--- a/lib/qonfig.rb
+++ b/lib/qonfig.rb
@@ -12,6 +12,7 @@ module Qonfig
   require_relative 'qonfig/commands/compose'
   require_relative 'qonfig/commands/load_from_yaml'
   require_relative 'qonfig/commands/load_from_self'
+  require_relative 'qonfig/commands/load_from_env'
   require_relative 'qonfig/command_set'
   require_relative 'qonfig/settings'
   require_relative 'qonfig/settings/lock'

--- a/lib/qonfig.rb
+++ b/lib/qonfig.rb
@@ -13,6 +13,7 @@ module Qonfig
   require_relative 'qonfig/commands/load_from_yaml'
   require_relative 'qonfig/commands/load_from_self'
   require_relative 'qonfig/commands/load_from_env'
+  require_relative 'qonfig/commands/load_from_env/value_converter'
   require_relative 'qonfig/command_set'
   require_relative 'qonfig/settings'
   require_relative 'qonfig/settings/lock'

--- a/lib/qonfig/commands/add_nested_option.rb
+++ b/lib/qonfig/commands/add_nested_option.rb
@@ -23,6 +23,10 @@ module Qonfig
       # @api private
       # @since 0.1.0
       def initialize(key, nested_definitions)
+        unless key.is_a?(Symbol) || key.is_a?(String)
+          raise Qonfig::ArgumentError, 'Setting key should be a symbol or a string!'
+        end
+
         @key = key
         @nested_definitions = nested_definitions
       end

--- a/lib/qonfig/commands/add_option.rb
+++ b/lib/qonfig/commands/add_option.rb
@@ -23,6 +23,10 @@ module Qonfig
       # @api private
       # @since 0.1.0
       def initialize(key, value)
+        unless key.is_a?(Symbol) || key.is_a?(String)
+          raise Qonfig::ArgumentError, 'Setting key should be a symbol or a string!'
+        end
+
         @key   = key
         @value = value
       end

--- a/lib/qonfig/commands/load_from_env.rb
+++ b/lib/qonfig/commands/load_from_env.rb
@@ -53,35 +53,11 @@ module Qonfig
       #
       # @api private
       # @since 0.2.0
-      def extract_env_data(&block)
+      def extract_env_data
         ENV.each_with_object({}) do |(key, value), env_data|
           env_data[key] = value if key.match(prefix_pattern)
         end.tap do |env_data|
-          convert_env_values!(env_data) if convert_values
-        end
-      end
-
-      # @param env_data [Hash]
-      # @return [Hash]
-      #
-      # @api private
-      # @since 0.2.0
-      def convert_env_values!(env_data)
-        env_data.each_pair do |key, value|
-          if value.is_a?(String)
-            value = begin
-              case value
-              when /\A\d+\z/              then Integer(value)
-              when /\A\d+\.\d+\z/         then Float(value)
-              when /\A(t|true|TRUE)\z/i   then true
-              when /\A(f|false|FALSE)\z/i then false
-              else
-                value
-              end
-            end
-          end
-
-          env_data[key] = value
+          ValueConverter.convert_values!(env_data) if convert_values
         end
       end
 

--- a/lib/qonfig/commands/load_from_env.rb
+++ b/lib/qonfig/commands/load_from_env.rb
@@ -5,6 +5,94 @@ module Qonfig
     # @api private
     # @since 0.2.0
     class LoadFromENV < Base
+      # @return [Boolean]
+      #
+      # @api private
+      # @since 0.2.0
+      attr_reader :convert_values
+
+      # @return [Regexp]
+      #
+      # @api private
+      # @since 0.2.0
+      attr_reader :prefix_pattern
+
+      # @option convert_values [Boolean]
+      #
+      # @api private
+      # @since 0.2.0
+      def initialize(convert_values: false, prefix: nil)
+        unless convert_values.is_a?(FalseClass) || convert_values.is_a?(TrueClass)
+          raise Qonfig::ArgumentError, ':convert_values option should be a boolean'
+        end
+
+        unless prefix.is_a?(NilClass) || prefix.is_a?(String) || prefix.is_a?(Regexp)
+          raise Qonfig::ArgumentError, ':prefix option should be a nil / string / regexp'
+        end
+
+        @convert_values = convert_values
+        @prefix_pattern = prefix.is_a?(Regexp) ? prefix : /\A#{Regexp.escape(prefix.to_s)}.*/m
+      end
+
+      # @param settings [Qonfig::Settings]
+      # @return [void]
+      #
+      # @api private
+      # @since 0.2.0
+      def call(settings)
+        env_data = extract_env_data
+
+        env_based_settings = build_data_set_class(env_data).new.settings
+
+        settings.__append_settings__(env_based_settings)
+      end
+
+      private
+
+      # @return [Hash]
+      #
+      # @api private
+      # @since 0.2.0
+      def extract_env_data(&block)
+        ENV.each_with_object({}) do |(key, value), env_data|
+          env_data[key] = value if key.match(prefix_pattern)
+        end.tap do |env_data|
+          convert_env_values!(env_data) if convert_values
+        end
+      end
+
+      # @param env_data [Hash]
+      # @return [Hash]
+      #
+      # @api private
+      # @since 0.2.0
+      def convert_env_values!(env_data)
+        env_data.each_pair do |key, value|
+          if value.is_a?(String)
+            value = begin
+              case value
+              when /\A\d+\z/              then Integer(value)
+              when /\A\d+\.\d+\z/         then Float(value)
+              when /\A(t|true|TRUE)\z/i   then true
+              when /\A(f|false|FALSE)\z/i then false
+              else
+                value
+              end
+            end
+          end
+
+          env_data[key] = value
+        end
+      end
+
+      # @param env_data [Hash]
+      # @return [Class<Qonfig::DataSet>]
+      #
+      # @api private
+      # @since 0.2.0
+      def build_data_set_class(env_data)
+        Qonfig::DataSet::ClassBuilder.build_from_hash(env_data)
+      end
     end
   end
 end

--- a/lib/qonfig/commands/load_from_env.rb
+++ b/lib/qonfig/commands/load_from_env.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Qonfig
+  module Commands
+    # @api private
+    # @since 0.2.0
+    class LoadFromENV < Base
+    end
+  end
+end

--- a/lib/qonfig/commands/load_from_env.rb
+++ b/lib/qonfig/commands/load_from_env.rb
@@ -18,6 +18,7 @@ module Qonfig
       attr_reader :prefix_pattern
 
       # @option convert_values [Boolean]
+      # @opion prefix [NilClass, String, Regexp]
       #
       # @api private
       # @since 0.2.0
@@ -31,7 +32,7 @@ module Qonfig
         end
 
         @convert_values = convert_values
-        @prefix_pattern = prefix.is_a?(Regexp) ? prefix : /\A#{Regexp.escape(prefix.to_s)}.*/m
+        @prefix_pattern = prefix.is_a?(Regexp) ? prefix : /\A#{Regexp.escape(prefix.to_s)}.*\z/m
       end
 
       # @param settings [Qonfig::Settings]

--- a/lib/qonfig/commands/load_from_env/value_converter.rb
+++ b/lib/qonfig/commands/load_from_env/value_converter.rb
@@ -4,9 +4,28 @@ module Qonfig
   # @api private
   # @since 0.2.0
   module Commands::LoadFromENV::ValueConverter
+    # @return [Regexp]
+    #
+    # @api private
+    # @since 0.2.0
     INTEGER_PATTERN = /\A\d+\z/
+
+    # @return [Regexp]
+    #
+    # @api private
+    # @since 0.2.0
     FLOAT_PATTERN   = /\A\d+\.\d+\z/
+
+    # @return [Regexp]
+    #
+    # @api private
+    # @since 0.2.0
     TRUE_PATTERN    = /\A(t|true)\z/i
+
+    # @return [Regexp]
+    #
+    # @api private
+    # @since 0.2.0
     FALSE_PATTERN   = /\A(f|false)\z/i
 
     class << self

--- a/lib/qonfig/commands/load_from_env/value_converter.rb
+++ b/lib/qonfig/commands/load_from_env/value_converter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Qonfig
+  # @api private
+  # @since 0.2.0
+  module Commands::LoadFromENV::ValueConverter
+    INTEGER_PATTERN = /\A\d+\z/
+    FLOAT_PATTERN   = /\A\d+\.\d+\z/
+    TRUE_PATTERN    = /\A(t|true)\z/i
+    FALSE_PATTERN   = /\A(f|false)\z/i
+
+    class << self
+      # @param env_data [Hash]
+      # @return [void]
+      #
+      # @api private
+      # @since 0.2.0
+      def convert_values!(env_data)
+        env_data.each_pair do |key, value|
+          env_data[key] = convert_value(value)
+        end
+      end
+
+      private
+
+      # @param value [Object]
+      # @return [Object]
+      #
+      # @api private
+      # @since 0.2.0
+      def convert_value(value)
+        return value unless value.is_a?(String)
+
+        case value
+        when INTEGER_PATTERN then Integer(value)
+        when FLOAT_PATTERN   then Float(value)
+        when TRUE_PATTERN    then true
+        when FALSE_PATTERN   then false
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/qonfig/dsl.rb
+++ b/lib/qonfig/dsl.rb
@@ -84,5 +84,15 @@ module Qonfig
       caller_location = caller(1, 1).first
       commands << Qonfig::Commands::LoadFromSelf.new(caller_location)
     end
+
+    # @return [void]
+    #
+    # @see Qonfig::Commands::LoadFromENV
+    #
+    # @api public
+    # @since 0.2.0
+    def load_from_env
+      commands << Qonfig::Commands::LoadFromENV.new
+    end
   end
 end

--- a/lib/qonfig/dsl.rb
+++ b/lib/qonfig/dsl.rb
@@ -41,10 +41,6 @@ module Qonfig
     # @api public
     # @since 0.1.0
     def setting(key, initial_value = nil, &nested_settings)
-      unless key.is_a?(Symbol) || key.is_a?(String)
-        raise Qonfig::ArgumentError, 'Setting key should be a symbol or a string!'
-      end
-
       if block_given?
         commands << Qonfig::Commands::AddNestedOption.new(key, nested_settings)
       else
@@ -91,8 +87,8 @@ module Qonfig
     #
     # @api public
     # @since 0.2.0
-    def load_from_env
-      commands << Qonfig::Commands::LoadFromENV.new
+    def load_from_env(convert_values: false)
+      commands << Qonfig::Commands::LoadFromENV.new(convert_values: convert_values)
     end
   end
 end

--- a/lib/qonfig/dsl.rb
+++ b/lib/qonfig/dsl.rb
@@ -87,8 +87,11 @@ module Qonfig
     #
     # @api public
     # @since 0.2.0
-    def load_from_env(convert_values: false)
-      commands << Qonfig::Commands::LoadFromENV.new(convert_values: convert_values)
+    def load_from_env(convert_values: false, prefix: nil)
+      commands << Qonfig::Commands::LoadFromENV.new(
+        convert_values: convert_values,
+        prefix: prefix
+      )
     end
   end
 end

--- a/lib/qonfig/dsl.rb
+++ b/lib/qonfig/dsl.rb
@@ -81,6 +81,8 @@ module Qonfig
       commands << Qonfig::Commands::LoadFromSelf.new(caller_location)
     end
 
+    # @option convert_values [Boolean]
+    # @option prefix [NilClass, String, Regexp]
     # @return [void]
     #
     # @see Qonfig::Commands::LoadFromENV

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -273,6 +273,45 @@ describe 'Config definition' do
     end.not_to raise_error
   end
 
+  specify 'fails when tries to use a non-string/non-symbol value as a setting key' do
+    incorrect_key_values = [123, Object.new, 15.1, (proc {}), Class.new, true, false]
+    correct_key_values   = ['test', :test]
+
+    incorrect_key_values.each do |incorrect_key|
+      # check root
+      expect do
+        Class.new(Qonfig::DataSet) { setting incorrect_key }
+      end.to raise_error(Qonfig::ArgumentError)
+
+      # check nested
+      expect do
+        Class.new(Qonfig::DataSet) do
+          setting incorrect_key do
+            setting :any
+          end
+        end
+      end.to raise_error(Qonfig::ArgumentError)
+    end
+
+    correct_key_values.each do |correct_key|
+      # check root
+      expect do
+        Class.new(Qonfig::DataSet) do
+          setting correct_key
+        end
+      end.not_to raise_error
+
+      # check nested
+      expect do
+        Class.new(Qonfig::DataSet) do
+          setting correct_key do
+            setting :any
+          end
+        end
+      end.not_to raise_error
+    end
+  end
+
   specify '#dig functionality' do
     class DiggingConfig < Qonfig::DataSet
       setting :db do

--- a/spec/features/load_from_env_spec.rb
+++ b/spec/features/load_from_env_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe 'Load from ENV' do
+  specify 'defines config object by ENV data' do
+    ENV['QONFIG_SPEC_LOAD_ENTRIES'] = 'true'
+    ENV['QONFIG_SPEC_RUN_CI_HOOKS'] = '1'
+
+    class EnvConfig < Qonfig::DataSet
+      setting :env do
+        load_from_env
+      end
+
+      setting :converted do
+        load_from_env convert_values: true
+      end
+    end
+
+    config = EnvConfig.new
+
+    # non-converted values
+    expect(config['env']['QONFIG_SPEC_LOAD_ENTRIES']).to eq('true')
+    expect(config['env']['QONFIG_SPEC_RUN_CI_HOOKS']).to eq('1')
+
+    # converted values
+    expect(config['converted']['QONFIG_SPEC_LOAD_ENTRIES']).to eq(true)
+    expect(config['converted']['QONFIG_SPEC_RUN_CI_HOOKS']).to eq(1)
+  end
+end

--- a/spec/features/load_from_env_spec.rb
+++ b/spec/features/load_from_env_spec.rb
@@ -34,7 +34,7 @@ describe 'Load from ENV' do
       end
 
       setting :prefix_regexp do
-        load_from_env prefix: /\Aqonfig.*?\z/i
+        load_from_env prefix: /\Aqonfig.*\z/i
       end
 
       setting :all_in do

--- a/spec/features/load_from_env_spec.rb
+++ b/spec/features/load_from_env_spec.rb
@@ -2,27 +2,163 @@
 
 describe 'Load from ENV' do
   specify 'defines config object by ENV data' do
-    ENV['QONFIG_SPEC_LOAD_ENTRIES'] = 'true'
-    ENV['QONFIG_SPEC_RUN_CI_HOOKS'] = '1'
+    ENV['QONFIG_SPEC_TRUE_VALUE_V1'] = 'true'
+    ENV['QONFIG_SPEC_TRUE_VALUE_V2'] = 't'
+    ENV['QONFIG_SPEC_TRUE_VALUE_V3'] = 'TRUE'
+    ENV['QONFIG_SPEC_TRUE_VALUE_V4'] = 'T'
+
+    ENV['QONFIG_SPEC_FALSE_VALUE_V1'] = 'false'
+    ENV['QONFIG_SPEC_FALSE_VALUE_V2'] = 'f'
+    ENV['QONFIG_SPEC_FALSE_VALUE_V3'] = 'FALSE'
+    ENV['QONFIG_SPEC_FALSE_VALUE_V4'] = 'F'
+
+    ENV['QONFIG_SPEC_INTEGER_VALUE'] = '1'
+    ENV['QONFIG_SPEC_FLOAT_VALUE']   = '1.55'
+
+    ENV['QONFIG_SPEC_GENERIC_VALUE_V1'] = '1,66'
+    ENV['QONFIG_SPEC_GENERIC_VALUE_V2'] = '123.456trueTRUEfalseFALSEtTfF.123'
+
+    ENV['NON_QONFIG_SPEC_GENERIC_VALUE'] = 'test'
 
     class EnvConfig < Qonfig::DataSet
-      setting :env do
+      setting :default do
         load_from_env
       end
 
       setting :converted do
         load_from_env convert_values: true
       end
+
+      setting :prefixed do
+        load_from_env prefix: 'QONFIG_'
+      end
+
+      setting :prefix_regexp do
+        load_from_env prefix: /\Aqonfig.*?\z/i
+      end
+
+      setting :all_in do
+        load_from_env convert_values: true, prefix: 'QONFIG'
+      end
     end
 
     config = EnvConfig.new
 
-    # non-converted values
-    expect(config['env']['QONFIG_SPEC_LOAD_ENTRIES']).to eq('true')
-    expect(config['env']['QONFIG_SPEC_RUN_CI_HOOKS']).to eq('1')
+    # rubocop:disable Metrics/LineLength
+    expect(config[:default][:QONFIG_SPEC_TRUE_VALUE_V1]).to     eq('true')
+    expect(config[:default][:QONFIG_SPEC_TRUE_VALUE_V2]).to     eq('t')
+    expect(config[:default][:QONFIG_SPEC_TRUE_VALUE_V3]).to     eq('TRUE')
+    expect(config[:default][:QONFIG_SPEC_TRUE_VALUE_V4]).to     eq('T')
+    expect(config[:default][:QONFIG_SPEC_FALSE_VALUE_V1]).to    eq('false')
+    expect(config[:default][:QONFIG_SPEC_FALSE_VALUE_V2]).to    eq('f')
+    expect(config[:default][:QONFIG_SPEC_FALSE_VALUE_V3]).to    eq('FALSE')
+    expect(config[:default][:QONFIG_SPEC_FALSE_VALUE_V4]).to    eq('F')
+    expect(config[:default][:QONFIG_SPEC_INTEGER_VALUE]).to     eq('1')
+    expect(config[:default][:QONFIG_SPEC_FLOAT_VALUE]).to       eq('1.55')
+    expect(config[:default][:QONFIG_SPEC_GENERIC_VALUE_V1]).to  eq('1,66')
+    expect(config[:default][:QONFIG_SPEC_GENERIC_VALUE_V2]).to  eq('123.456trueTRUEfalseFALSEtTfF.123')
+    expect(config[:default][:NON_QONFIG_SPEC_GENERIC_VALUE]).to eq('test')
 
-    # converted values
-    expect(config['converted']['QONFIG_SPEC_LOAD_ENTRIES']).to eq(true)
-    expect(config['converted']['QONFIG_SPEC_RUN_CI_HOOKS']).to eq(1)
+    expect(config[:converted][:QONFIG_SPEC_TRUE_VALUE_V1]).to     eq(true)
+    expect(config[:converted][:QONFIG_SPEC_TRUE_VALUE_V2]).to     eq(true)
+    expect(config[:converted][:QONFIG_SPEC_TRUE_VALUE_V3]).to     eq(true)
+    expect(config[:converted][:QONFIG_SPEC_TRUE_VALUE_V4]).to     eq(true)
+    expect(config[:converted][:QONFIG_SPEC_FALSE_VALUE_V1]).to    eq(false)
+    expect(config[:converted][:QONFIG_SPEC_FALSE_VALUE_V2]).to    eq(false)
+    expect(config[:converted][:QONFIG_SPEC_FALSE_VALUE_V3]).to    eq(false)
+    expect(config[:converted][:QONFIG_SPEC_FALSE_VALUE_V4]).to    eq(false)
+    expect(config[:converted][:QONFIG_SPEC_INTEGER_VALUE]).to     eq(1)
+    expect(config[:converted][:QONFIG_SPEC_FLOAT_VALUE]).to       eq(1.55)
+    expect(config[:converted][:QONFIG_SPEC_GENERIC_VALUE_V1]).to  eq('1,66')
+    expect(config[:converted][:QONFIG_SPEC_GENERIC_VALUE_V2]).to  eq('123.456trueTRUEfalseFALSEtTfF.123')
+    expect(config[:converted][:NON_QONFIG_SPEC_GENERIC_VALUE]).to eq('test')
+
+    expect(config[:prefixed][:QONFIG_SPEC_TRUE_VALUE_V1]).to        eq('true')
+    expect(config[:prefixed][:QONFIG_SPEC_TRUE_VALUE_V2]).to        eq('t')
+    expect(config[:prefixed][:QONFIG_SPEC_TRUE_VALUE_V3]).to        eq('TRUE')
+    expect(config[:prefixed][:QONFIG_SPEC_TRUE_VALUE_V4]).to        eq('T')
+    expect(config[:prefixed][:QONFIG_SPEC_FALSE_VALUE_V1]).to       eq('false')
+    expect(config[:prefixed][:QONFIG_SPEC_FALSE_VALUE_V2]).to       eq('f')
+    expect(config[:prefixed][:QONFIG_SPEC_FALSE_VALUE_V3]).to       eq('FALSE')
+    expect(config[:prefixed][:QONFIG_SPEC_FALSE_VALUE_V4]).to       eq('F')
+    expect(config[:prefixed][:QONFIG_SPEC_INTEGER_VALUE]).to        eq('1')
+    expect(config[:prefixed][:QONFIG_SPEC_FLOAT_VALUE]).to          eq('1.55')
+    expect(config[:prefixed][:QONFIG_SPEC_GENERIC_VALUE_V1]).to     eq('1,66')
+    expect(config[:prefixed][:QONFIG_SPEC_GENERIC_VALUE_V2]).to     eq('123.456trueTRUEfalseFALSEtTfF.123')
+    expect { config[:prefixed][:NON_QONFIG_SPEC_GENERIC_VALUE] }.to raise_error(Qonfig::UnknownSettingError)
+
+    expect(config[:prefix_regexp][:QONFIG_SPEC_TRUE_VALUE_V1]).to        eq('true')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_TRUE_VALUE_V2]).to        eq('t')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_TRUE_VALUE_V3]).to        eq('TRUE')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_TRUE_VALUE_V4]).to        eq('T')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_FALSE_VALUE_V1]).to       eq('false')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_FALSE_VALUE_V2]).to       eq('f')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_FALSE_VALUE_V3]).to       eq('FALSE')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_FALSE_VALUE_V4]).to       eq('F')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_INTEGER_VALUE]).to        eq('1')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_FLOAT_VALUE]).to          eq('1.55')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_GENERIC_VALUE_V1]).to     eq('1,66')
+    expect(config[:prefix_regexp][:QONFIG_SPEC_GENERIC_VALUE_V2]).to     eq('123.456trueTRUEfalseFALSEtTfF.123')
+    expect { config[:prefix_regexp][:NON_QONFIG_SPEC_GENERIC_VALUE] }.to raise_error(Qonfig::UnknownSettingError)
+
+    expect(config[:all_in][:QONFIG_SPEC_TRUE_VALUE_V1]).to     eq(true)
+    expect(config[:all_in][:QONFIG_SPEC_TRUE_VALUE_V2]).to     eq(true)
+    expect(config[:all_in][:QONFIG_SPEC_TRUE_VALUE_V3]).to     eq(true)
+    expect(config[:all_in][:QONFIG_SPEC_TRUE_VALUE_V4]).to     eq(true)
+    expect(config[:all_in][:QONFIG_SPEC_FALSE_VALUE_V1]).to    eq(false)
+    expect(config[:all_in][:QONFIG_SPEC_FALSE_VALUE_V2]).to    eq(false)
+    expect(config[:all_in][:QONFIG_SPEC_FALSE_VALUE_V3]).to    eq(false)
+    expect(config[:all_in][:QONFIG_SPEC_FALSE_VALUE_V4]).to    eq(false)
+    expect(config[:all_in][:QONFIG_SPEC_INTEGER_VALUE]).to     eq(1)
+    expect(config[:all_in][:QONFIG_SPEC_FLOAT_VALUE]).to       eq(1.55)
+    expect(config[:all_in][:QONFIG_SPEC_GENERIC_VALUE_V1]).to  eq('1,66')
+    expect(config[:all_in][:QONFIG_SPEC_GENERIC_VALUE_V2]).to  eq('123.456trueTRUEfalseFALSEtTfF.123')
+    expect { config[:all_in][:NON_QONFIG_SPEC_GENERIC_VALUE] }.to raise_error(Qonfig::UnknownSettingError)
+    # rubocop:enable Metrics/LineLength
+  end
+
+  specify 'incorrect definition' do
+    incorrect_convert_value_option_values = [
+      123, '123', 'true', 't', 'false', 'f', Object.new, 123.5, Class.new
+    ]
+
+    incorrect_prefix_option_values = [
+      123, Object.new, 123.5, true, false, Class.new
+    ]
+
+    correct_convert_value_option_values = [true, false]
+    correct_prefix_option_values = [nil, 'qonfig', /\Aqonfig.*\z/i]
+
+    incorrect_convert_value_option_values.each do |incorrect_option|
+      expect do
+        Class.new(Qonfig::DataSet) do
+          load_from_env convert_values: incorrect_option
+        end
+      end.to raise_error(Qonfig::ArgumentError)
+    end
+
+    incorrect_prefix_option_values.each do |incorrect_option|
+      expect do
+        Class.new(Qonfig::DataSet) do
+          load_from_env prefix: incorrect_option
+        end
+      end.to raise_error(Qonfig::ArgumentError)
+    end
+
+    correct_convert_value_option_values.each do |correct_option|
+      expect do
+        Class.new(Qonfig::DataSet) do
+          load_from_env convert_values: correct_option
+        end
+      end.not_to raise_error
+    end
+
+    correct_prefix_option_values.each do |correct_option|
+      expect do
+        Class.new(Qonfig::DataSet) do
+          load_from_env prefix: correct_option
+        end
+      end.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
#12 

---

API:

```ruby
# some env variables
ENV['QONFIG_SETTINGS'] = 'true'
ENV['QONFIG_TIMEOUT'] = '0'
ENV['QONFIG_SPECS'] = 'none'
ENV['RUN_CI'] = '1'

class Config < Qonfig::DataSet
  # nested (and customized)
  setting :qonfig do
    load_from_env convert_values: true, prefix: 'QONFIG'
  end

  # on the root (with defaults)
  load_from_env
end

config = Config.new

# customized
config['qonfig']['QONFIG_SETTINGS'] # => true ('true' => true)
config['qonfig']['QONFIG_TIMEOUT'] # => 0 ('0' => 0)
config['qonfig']['QONFIG_SPECS'] # => 'none'
config['qonfig']['RUN_CI'] # => Qonfig::UnknownSettingError

# default
config['QONFIG_SETTINGS'] # => 'true'
config['QONFIG_TIMEOUT'] # => '0'
conifg['QONFIG_SPECS'] # => 'none'
config['RUN_CI'] # => '1'
```

---

For more details see CHANGELOG.md and README.md