### PR TITLE
Prevent Qonfig::Settings instance method redefinition inside nested definitions at the class definition step

### DIFF
--- a/lib/qonfig.rb
+++ b/lib/qonfig.rb
@@ -18,6 +18,7 @@ module Qonfig
   require_relative 'qonfig/settings'
   require_relative 'qonfig/settings/lock'
   require_relative 'qonfig/settings/builder'
+  require_relative 'qonfig/settings/key_guard'
   require_relative 'qonfig/dsl'
   require_relative 'qonfig/data_set'
   require_relative 'qonfig/data_set/class_builder'

--- a/lib/qonfig/commands/add_nested_option.rb
+++ b/lib/qonfig/commands/add_nested_option.rb
@@ -38,6 +38,10 @@ module Qonfig
 
         @key = key
         @nested_definitions = nested_definitions
+
+        @nested_data_set_klass = Class.new(Qonfig::DataSet).tap do |data_set|
+          data_set.instance_eval(&nested_definitions)
+        end
       end
 
       # @param settings [Qonfig::Settings]

--- a/lib/qonfig/commands/add_option.rb
+++ b/lib/qonfig/commands/add_option.rb
@@ -26,17 +26,9 @@ module Qonfig
       # @api private
       # @since 0.1.0
       def initialize(key, value)
-        raise(
-          Qonfig::ArgumentError,
-          'Setting key should be a symbol or a string!'
-        ) unless key.is_a?(Symbol) || key.is_a?(String)
+        Qonfig::Settings::KeyGuard.prevent_incomparabilities!(key)
 
-        raise(
-          Qonfig::CoreMethodIntersectionError,
-          "<#{key}> key can not be used since this is a private core method"
-        ) if Qonfig::Settings.intersects_core_method?(key)
-
-        @key   = key
+        @key = key
         @value = value
       end
 

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -6,17 +6,6 @@ module Qonfig
   # @api private
   # @since 0.1.0
   class Settings
-    class << self
-      # @param setting_key [String, Symbol]
-      # @return [Boolean]
-      #
-      # @api private
-      # @since 0.2.0
-      def intersects_core_method?(setting_key)
-        CORE_METHODS.include?(setting_key.to_s)
-      end
-    end
-
     # @return [Hash]
     #
     # @api private
@@ -40,7 +29,7 @@ module Qonfig
       __lock__.thread_safe_definition do
         key = __indifferently_accessable_option_key__(key)
 
-        __prevent_core_method_redefinition__(key)
+        __prevent_core_method_intersection__(key)
 
         case
         when !__options__.key?(key)
@@ -293,33 +282,25 @@ module Qonfig
     # @return [String]
     #
     # @raise [Qonfig::ArgumentError]
+    # @see Qonfig::Settings::KeyGuard
     #
     # @api private
     # @since 0.2.0
     def __indifferently_accessable_option_key__(key)
-      # :nocov:
-      unless key.is_a?(Symbol) || key.is_a?(String)
-        raise Qonfig::ArgumentError, 'Setting key should be a symbol or a string'
-      end
-      # :nocov:
-
+      KeyGuard.new(key).prevent_incompatible_key_type!
       key.to_s
     end
 
-    # @param setting_key [String]
+    # @param key [Symbol, String]
     # @return [void]
     #
     # @raise [Qonfig::CoreMethodIntersectionError]
+    # @see Qonfig::Settings::KeyGuard
     #
     # @api private
     # @since 0.2.0
-    def __prevent_core_method_redefinition__(setting_key)
-      # :nocov:
-      raise(
-        Qonfig::CoreMethodIntersectionError,
-        "<#{setting_key}> key can not be used since this is a private core method"
-      ) if self.class.intersects_core_method?(setting_key)
-      # :nocov:
+    def __prevent_core_method_intersection__(key)
+      KeyGuard.new(key).prevent_core_method_intersection!
     end
 
     # @return [Array<String>]

--- a/lib/qonfig/settings/key_guard.rb
+++ b/lib/qonfig/settings/key_guard.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Qonfig
+  class Settings
+    # @api private
+    # @since 0.2.0
+    class KeyGuard
+      class << self
+        # @param key [String, Symbol, Object]
+        # @return [void]
+        #
+        # @raise [Qonfig::ArgumentError]
+        # @raise [Qonfig::CoreMethodIntersectionError]
+        #
+        # @api private
+        # @since 0.2.0
+        def prevent_incomparabilities!(key)
+          new(key).prevent_incomparabilities!
+        end
+      end
+
+      # @return [String, Symbol, Object]
+      #
+      # @api private
+      # @sicne 0.2.0
+      attr_reader :key
+
+      # @param key [String, Symbol, Object]
+      #
+      # @api private
+      # @since 0.2.0
+      def initialize(key)
+        @key = key
+      end
+
+      # @return [void]
+      #
+      # @raise [Qonfig::ArgumentError]
+      # @raise [Qonfig::CoreMethodIntersectionError]
+      #
+      # @api private
+      # @since 0.2.0
+      def prevent_incomparabilities!
+        prevent_incompatible_key_type!
+        prevent_core_method_intersection!
+      end
+
+      # @return [void]
+      #
+      # @raise [Qonfig::ArgumentError]
+      #
+      # @api private
+      # @since 0.2.0
+      def prevent_incompatible_key_type!
+        raise(
+          Qonfig::ArgumentError,
+          'Setting key should be a symbol or a string!'
+        ) unless key.is_a?(Symbol) || key.is_a?(String)
+      end
+
+      # @return [void]
+      #
+      # @raise [Qonfig::CoreMethodIntersectionError]
+      #
+      # @api private
+      # @since 0.2.0
+      def prevent_core_method_intersection!
+        raise(
+          Qonfig::CoreMethodIntersectionError,
+          "<#{key}> key can not be used since this is a private core method"
+        ) if Qonfig::Settings::CORE_METHODS.include?(key.to_s)
+      end
+    end
+  end
+end

--- a/spec/features/core_methods_redefenition_spec.rb
+++ b/spec/features/core_methods_redefenition_spec.rb
@@ -13,6 +13,14 @@ describe 'Core methods redefinition' do
           setting core_method
         end
       end.to raise_error(Qonfig::CoreMethodIntersectionError)
+
+     expect do
+        Class.new(Qonfig::DataSet) do
+          setting :any_key do
+            setting core_method
+          end
+        end
+      end.to raise_error(Qonfig::CoreMethodIntersectionError)
     end
   end
 end

--- a/spec/features/core_methods_redefenition_spec.rb
+++ b/spec/features/core_methods_redefenition_spec.rb
@@ -14,7 +14,7 @@ describe 'Core methods redefinition' do
         end
       end.to raise_error(Qonfig::CoreMethodIntersectionError)
 
-     expect do
+      expect do
         Class.new(Qonfig::DataSet) do
           setting :any_key do
             setting core_method

--- a/spec/features/core_methods_redefenition_spec.rb
+++ b/spec/features/core_methods_redefenition_spec.rb
@@ -7,6 +7,8 @@ describe 'Core methods redefinition' do
       Qonfig::Settings.private_instance_methods(false)
     )
 
+    expect(core_methods).not_to include(:super_test_key)
+
     core_methods.each do |core_method|
       expect do
         Class.new(Qonfig::DataSet) do
@@ -16,7 +18,7 @@ describe 'Core methods redefinition' do
 
       expect do
         Class.new(Qonfig::DataSet) do
-          setting :any_key do
+          setting :super_test_key do
             setting core_method
           end
         end


### PR DESCRIPTION
Actual problematic behaviour:

```ruby
# without nesting
class Config < Qonfig::DataSet
   setting :__options__ # private core method
end
# (OK) => Qonfig::CoreMethodIntersectionError
```

```ruby
# with nesting
class Config < Qonfig::DataSet
   setting :some_key do
       setting :__options__ # private core method (inside the nested definition)
   end
end
# (PROBLEM) => ...no error =(

# but we cant instantiate (and it is good)
Config.new # (OK) => Qonfig::CoreMethodIntersectionError
```

Throw `Qonfig::CoreMethodIntersectionError` in case with the nested redefinition at the class definition step.