### PR TITLE
Configure via hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 Gemfile.lock
 /.idea
 .ruby-version
+/.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- Improved configuration process: `#configure` can take a hash as a configuration `[option key => option]` value map;
+- Improved configuration process: `#configure` can take a hash as a configuration `[option key => option]`
+  map of values;
 
 ## [0.2.0] - 2018-06-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Improved configuration process: `#configure` can take a hash as a configuration `[option key => option]` value map;
+
 ## [0.2.0] - 2018-06-07
 ### Added
 - Instant configuration via block `config = Config.new { |conf| <<your configuration code>> }`;

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ config.settings['RUN_CI'] # => '1'
 class Config < Qonfig::DataSet
   load_from_self # on the root
 
-  setting :clowd do
+  setting :nested do
     load_from_self # nested
   end
 end

--- a/README.md
+++ b/README.md
@@ -131,6 +131,23 @@ config = Config.new do |conf|
   conf.geo_api.provider = :amazon_maps
   conf.testing.engine = :crypto_test
 end
+
+# using a hash
+config = Config.new(
+  testing: { engine: :mini_test, parallel: false },
+  geo_api: { provider: :rambler_maps },
+  enable_middlewares: true
+)
+config.configure(enable_middlewares: false)
+
+# using both hash and proc (proc has higher priority)
+config = Config.new(enable_middlewares: true) do |conf|
+  conf.testing.parallel = true
+end
+
+config.configure(geo_api: { provider: nil }) do |conf|
+  conf.testing.engine = :rspec
+end
 ```
 
 ---

--- a/lib/qonfig/configurable.rb
+++ b/lib/qonfig/configurable.rb
@@ -64,9 +64,9 @@ module Qonfig
       #
       # @api public
       # @since 0.2.0
-      def configure(options_map = {}, &block) # settings hash as an attribute
+      def configure(options_map = {}, &block)
         @__qonfig_access_lock__.synchronize do
-          config.configure(&block) if block_given?
+          config.configure(options_map, &block)
         end
       end
 
@@ -100,9 +100,9 @@ module Qonfig
       #
       # @api public
       # @since 0.2.0
-      def configure(options_map = {}, &block) # settings hash as an attribute
+      def configure(options_map = {}, &block)
         self.class.instance_variable_get(:@__qonfig_access_lock__).synchronize do
-          config.configure(&block) if block_given?
+          config.configure(options_map, &block)
         end
       end
     end

--- a/lib/qonfig/configurable.rb
+++ b/lib/qonfig/configurable.rb
@@ -58,12 +58,13 @@ module Qonfig
         end
       end
 
+      # @param options_map [Hash]
       # @param block [Proc]
       # @return [void]
       #
       # @api public
       # @since 0.2.0
-      def configure(&block)
+      def configure(options_map = {}, &block) # settings hash as an attribute
         @__qonfig_access_lock__.synchronize do
           config.configure(&block) if block_given?
         end
@@ -93,12 +94,13 @@ module Qonfig
         end
       end
 
+      # @param options_map [Hash]
       # @param block [Proc]
       # @return [void]
       #
       # @api public
       # @since 0.2.0
-      def configure(&block)
+      def configure(options_map = {}, &block) # settings hash as an attribute
         self.class.instance_variable_get(:@__qonfig_access_lock__).synchronize do
           config.configure(&block) if block_given?
         end

--- a/lib/qonfig/data_set.rb
+++ b/lib/qonfig/data_set.rb
@@ -13,15 +13,16 @@ module Qonfig
     # @since 0.1.0
     attr_reader :settings
 
+    # @param options_map [Hash]
     # @param configurations [Proc]
     #
     # @api public
     # @since 0.1.0
-    def initialize(&configurations)
+    def initialize(options_map = {}, &configurations)
       @__access_lock__ = Mutex.new
       @__definition_lock__ = Mutex.new
 
-      thread_safe_definition { load!(&configurations) }
+      thread_safe_definition { load!(options_map, &configurations) }
     end
 
     # @return [void]
@@ -40,6 +41,7 @@ module Qonfig
       thread_safe_access { settings.__is_frozen__ }
     end
 
+    # @param options_map [Hash]
     # @param configurations [Proc]
     # @return [void]
     #
@@ -47,18 +49,19 @@ module Qonfig
     #
     # @api public
     # @since 0.2.0
-    def reload!(&configurations)
+    def reload!(options_map = {}, &configurations) # settings hash as an attribute
       thread_safe_definition do
         raise Qonfig::FrozenSettingsError, 'Frozen config can not be reloaded' if frozen?
-        load!(&configurations)
+        load!(options_map, &configurations)
       end
     end
 
+    # @param options_map [Hash]
     # @return [void]
     #
     # @api public
     # @since 0.1.0
-    def configure
+    def configure(options_map = {})
       thread_safe_access { yield(settings) if block_given? }
     end
 
@@ -107,14 +110,15 @@ module Qonfig
       Qonfig::Settings::Builder.build(self.class.commands.dup)
     end
 
+    # @param options_map [Hash]
     # @param configurations [Proc]
     # @return [void]
     #
     # @api private
     # @since 0.2.0
-    def load!(&configurations)
+    def load!(options_map = {}, &configurations) # settings hash as an attribute
       @settings = build_settings
-      configure(&configurations) if block_given?
+      configure(options_map, &configurations) if block_given?
     end
 
     # @param instructions [Proc]

--- a/lib/qonfig/data_set.rb
+++ b/lib/qonfig/data_set.rb
@@ -102,6 +102,13 @@ module Qonfig
 
     private
 
+    # @return [void]
+    #
+    # @api private
+    # @since 0.3.0
+    def apply_hash_settings
+    end
+
     # @return [Qonfig::Settings]
     #
     # @api private

--- a/lib/qonfig/data_set.rb
+++ b/lib/qonfig/data_set.rb
@@ -49,7 +49,7 @@ module Qonfig
     #
     # @api public
     # @since 0.2.0
-    def reload!(options_map = {}, &configurations) # settings hash as an attribute
+    def reload!(options_map = {}, &configurations)
       thread_safe_definition do
         raise Qonfig::FrozenSettingsError, 'Frozen config can not be reloaded' if frozen?
         load!(options_map, &configurations)
@@ -62,7 +62,10 @@ module Qonfig
     # @api public
     # @since 0.1.0
     def configure(options_map = {})
-      thread_safe_access { yield(settings) if block_given? }
+      thread_safe_access do
+        settings.__apply_values__(options_map)
+        yield(settings) if block_given?
+      end
     end
 
     # @return [Hash]
@@ -102,13 +105,6 @@ module Qonfig
 
     private
 
-    # @return [void]
-    #
-    # @api private
-    # @since 0.3.0
-    def apply_hash_settings
-    end
-
     # @return [Qonfig::Settings]
     #
     # @api private
@@ -123,9 +119,9 @@ module Qonfig
     #
     # @api private
     # @since 0.2.0
-    def load!(options_map = {}, &configurations) # settings hash as an attribute
+    def load!(options_map = {}, &configurations)
       @settings = build_settings
-      configure(options_map, &configurations) if block_given?
+      configure(options_map, &configurations)
     end
 
     # @param instructions [Proc]

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -169,6 +169,9 @@ module Qonfig
     # @param options_map [Hash]
     # @return [void]
     #
+    # @raise [Qonfig::ArgumentError]
+    # @raise [Qonfig::AmbiguousSettingValueError]
+    #
     # @api private
     # @since 0.3.0
     def __set_values_from_map__(options_map)

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -114,7 +114,7 @@ module Qonfig
     def method_missing(method_name, *arguments, &block)
       super
     rescue NoMethodError
-      raise Qonfig::UnknownSettingError, "Setting with <#{method_name}> key doesnt exist!"
+      ::Kernel.raise(Qonfig::UnknownSettingError, "Setting with <#{method_name}> key doesnt exist!")
     end
 
     # @return [Boolean]
@@ -176,7 +176,7 @@ module Qonfig
       key = __indifferently_accessable_option_key__(key)
 
       unless __options__.key?(key)
-        raise Qonfig::UnknownSettingError, "Setting with <#{key}> key does not exist!"
+        ::Kernel.raise(Qonfig::UnknownSettingError, "Setting with <#{key}> key does not exist!")
       end
 
       __options__[key]
@@ -196,15 +196,18 @@ module Qonfig
       key = __indifferently_accessable_option_key__(key)
 
       unless __options__.key?(key)
-        raise Qonfig::UnknownSettingError, "Setting with <#{key}> key does not exist!"
+        ::Kernel.raise(Qonfig::UnknownSettingError, "Setting with <#{key}> key does not exist!")
       end
 
       if __options__.frozen?
-        raise Qonfig::FrozenSettingsError, 'Can not modify frozen settings'
+        ::Kernel.raise(Qonfig::FrozenSettingsError, 'Can not modify frozen settings')
       end
 
       if __options__[key].is_a?(Qonfig::Settings)
-        raise Qonfig::AmbiguousSettingValueError, 'Can not redefine option with nested options'
+        ::Kernel.raise(
+          Qonfig::AmbiguousSettingValueError,
+          'Can not redefine option with nested options'
+        )
       end
 
       __options__[key] = value
@@ -220,7 +223,7 @@ module Qonfig
     # @api private
     # @since 0.2.0
     def __deep_access__(*keys)
-      raise Qonfig::ArgumentError, 'Key list can not be empty' if keys.empty?
+      ::Kernel.raise(Qonfig::ArgumentError, 'Key list can not be empty') if keys.empty?
 
       result = __get_value__(keys.first)
       rest_keys = Array(keys[1..-1])
@@ -229,7 +232,10 @@ module Qonfig
       when rest_keys.empty?
         result
       when !result.is_a?(Qonfig::Settings)
-        raise(Qonfig::UnknownSettingError, 'Setting with required digging sequence does not exist!')
+        ::Kernel.raise(
+          Qonfig::UnknownSettingError,
+          'Setting with required digging sequence does not exist!'
+        )
       when result.is_a?(Qonfig::Settings)
         result.__dig__(*rest_keys)
       end
@@ -310,7 +316,7 @@ module Qonfig
     CORE_METHODS = Array(
       instance_methods(false) |
       private_instance_methods(false) |
-      %i[super raise define_singleton_method]
+      %i[super define_singleton_method self]
     ).map(&:to_s).freeze
   end
 

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -172,7 +172,7 @@ module Qonfig
     # @api private
     # @since 0.3.0
     def __set_values_from_map__(options_map)
-      raise(
+      ::Kernel.raise(
         Qonfig::ArgumentError, 'Options map should be represented as a hash'
       ) unless options_map.is_a?(Hash)
 

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -179,11 +179,13 @@ module Qonfig
       options_map.each_pair do |key, value|
         current_value = __get_value__(key)
 
-        if !current_value.is_a?(Qonfig::Settings)
+        # NOTE: some duplications here was made only for the better code readability
+        case
+        when !current_value.is_a?(Qonfig::Settings)
           __set_value__(key, value)
-        elsif value.is_a?(Hash)
+        when current_value.is_a?(Qonfig::Settings) && value.is_a?(Hash)
           current_value.__apply_values__(value)
-        else
+        when current_value.is_a?(Qonfig::Settings) && !value.is_a?(Hash)
           ::Kernel.raise(
             Qonfig::AmbiguousSettingValueError,
             "Can not redefine option <#{key}> that contains nested options"

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -151,6 +151,12 @@ module Qonfig
 
     private
 
+    # @return [Qonfig::Settings::Lock]
+    #
+    # @api private
+    # @since 0.2.0
+    attr_reader :__lock__
+
     # @return [void]
     #
     # @api private
@@ -240,12 +246,6 @@ module Qonfig
         result.__dig__(*rest_keys)
       end
     end
-
-    # @return [Qonfig::Settings::Lock]
-    #
-    # @api private
-    # @since 0.2.0
-    attr_reader :__lock__
 
     # @param options_part [Hash]
     # @return [Hash]

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -177,6 +177,127 @@ describe 'Config definition' do
     )
   end
 
+  specify 'configuration via hash / hash + proc (instant and not)' do
+    class HashConfigurableConfig < Qonfig::DataSet
+      setting :a do
+        setting :b
+        setting :c
+      end
+
+      setting :d
+      setting :e
+    end
+
+    # configure by hash (via .new)
+    config = HashConfigurableConfig.new(
+      a: {
+        b: { g: 33 },
+        c: 2
+      },
+      d: 33,
+      e: { f: 49 }
+    )
+    expect(config.to_h).to match(
+      'a' => {
+        'b' => { g: 33 },
+        'c' => 2,
+      },
+      'd' => 33,
+      'e' => { f: 49 }
+    )
+
+    # configure by hash (via #configure)
+    config = HashConfigurableConfig.new
+    config.configure(
+      a: {
+        b: 'test',
+        c: 'no_test'
+      },
+      d: 100_500,
+      e: false
+    )
+    expect(config.to_h).to match(
+      'a' => {
+        'b' => 'test',
+        'c' => "no_test",
+      },
+      'd' => 100_500,
+      'e' => false
+    )
+
+    # mixed: configure by hash + proc (via .new)
+    config = HashConfigurableConfig.new(d: false, e: true) do |conf|
+      conf.a.b = 123
+      conf.a.c = 456
+    end
+    expect(config.to_h).to match(
+      'a' => {
+        'b' => 123,
+        'c' => 456,
+      },
+      'd' => false,
+      'e' => true
+    )
+
+    # mixed: configure by hash + proc (via #configure)
+    config = HashConfigurableConfig.new
+    config.configure(a: { b: { c: 49 }, c: 55 }) do |conf|
+      conf.d = 0.55
+      conf.e = false
+    end
+    expect(config.to_h).to match(
+      'a' => {
+        'b' => { c: 49 },
+        'c' => 55,
+      },
+      'd' => 0.55,
+      'e' => false
+    )
+
+    # proc has higher priority
+    config = HashConfigurableConfig.new(a: { b: 1, c: 2 }, d: 3, e: 4) do |conf|
+      conf.a.b = 5
+      conf.a.c = 6
+      conf.d = 7
+      conf.e = 8
+    end
+    expect(config.to_h).to match(
+      'a' => {
+        'b' => 5,
+        'c' => 6,
+      },
+      'd' => 7,
+      'e' => 8
+    )
+
+    expect do
+      # nonexistent nested key
+      HashConfigurableConfig.new(a: { e: 55 })
+    end.to raise_error(Qonfig::UnknownSettingError)
+    expect do
+      # nonexistend nested key + proc
+      HashConfigurableConfig.new(a: { e: 55 }) { |conf| conf.d = 'test' }
+    end.to raise_error(Qonfig::UnknownSettingError)
+
+    expect do
+      # nonexistent root key
+      HashConfigurableConfig.new(g: 'test')
+    end.to raise_error(Qonfig::UnknownSettingError)
+    expect do
+      # nonexistent root key + proc
+      HashConfigurableConfig.new(g: 'test') { |conf| conf.e = false }
+    end
+
+    expect do
+      # attempt to override nested settings
+      HashConfigurableConfig.new(a: 100)
+    end.to raise_error(Qonfig::AmbiguousSettingValueError)
+    expect do
+      # attempt to override nested settings (+ proc)
+      HashConfigurableConfig.new(a: 100) { |conf| conf.a.b = :none }
+    end.to raise_error(Qonfig::AmbiguousSettingValueError)
+  end
+
   specify 'only string and symbol keys are supported' do
     [1, 1.0, Object.new, true, false, Class.new, Module.new, (proc {}), (-> {})].each do |key|
       expect do

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -296,6 +296,19 @@ describe 'Config definition' do
       # attempt to override nested settings (+ proc)
       HashConfigurableConfig.new(a: 100) { |conf| conf.a.b = :none }
     end.to raise_error(Qonfig::AmbiguousSettingValueError)
+
+    # attempt to use non-hash object
+    [1, 1.0, Object.new, true, false, Class.new, Module.new, (proc {}), (-> {})].each do |non_hash|
+      expect do
+        # without proc
+        HashConfigurableConfig.new(non_hash)
+      end.to raise_error(Qonfig::ArgumentError)
+
+      expect do
+        # with valid proc
+        HashConfigurableConfig.new(non_hash) { |conf| conf.d = 55 }
+      end.to raise_error(Qonfig::ArgumentError)
+    end
   end
 
   specify 'only string and symbol keys are supported' do

--- a/spec/features/config_definition_spec.rb
+++ b/spec/features/config_definition_spec.rb
@@ -200,7 +200,7 @@ describe 'Config definition' do
     expect(config.to_h).to match(
       'a' => {
         'b' => { g: 33 },
-        'c' => 2,
+        'c' => 2
       },
       'd' => 33,
       'e' => { f: 49 }
@@ -219,7 +219,7 @@ describe 'Config definition' do
     expect(config.to_h).to match(
       'a' => {
         'b' => 'test',
-        'c' => "no_test",
+        'c' => 'no_test'
       },
       'd' => 100_500,
       'e' => false
@@ -233,7 +233,7 @@ describe 'Config definition' do
     expect(config.to_h).to match(
       'a' => {
         'b' => 123,
-        'c' => 456,
+        'c' => 456
       },
       'd' => false,
       'e' => true
@@ -248,7 +248,7 @@ describe 'Config definition' do
     expect(config.to_h).to match(
       'a' => {
         'b' => { c: 49 },
-        'c' => 55,
+        'c' => 55
       },
       'd' => 0.55,
       'e' => false
@@ -264,7 +264,7 @@ describe 'Config definition' do
     expect(config.to_h).to match(
       'a' => {
         'b' => 5,
-        'c' => 6,
+        'c' => 6
       },
       'd' => 7,
       'e' => 8
@@ -286,7 +286,7 @@ describe 'Config definition' do
     expect do
       # nonexistent root key + proc
       HashConfigurableConfig.new(g: 'test') { |conf| conf.e = false }
-    end
+    end.to raise_error(Qonfig::UnknownSettingError)
 
     expect do
       # attempt to override nested settings

--- a/spec/features/core_methods_redefenition_spec.rb
+++ b/spec/features/core_methods_redefenition_spec.rb
@@ -5,7 +5,7 @@ describe 'Core methods redefinition' do
     core_methods = (
       Qonfig::Settings.instance_methods(false) |
       Qonfig::Settings.private_instance_methods(false) |
-      %i[define_singleton_method super raise]
+      %i[define_singleton_method super self]
     )
 
     expect(core_methods).not_to include(:super_test_key)

--- a/spec/features/mixin_spec.rb
+++ b/spec/features/mixin_spec.rb
@@ -174,7 +174,6 @@ describe 'Mixin (Qonfig::Configurable)' do
     [AnyApplication, any_app].each do |configurable|
       expect do
         configurable.configure(env: { nonexistent_key: 100 })
-        binding.pry
       end.to raise_error(Qonfig::UnknownSettingError)
       expect do
         configurable.configure(nonexistent_key: false)

--- a/spec/features/mixin_spec.rb
+++ b/spec/features/mixin_spec.rb
@@ -159,7 +159,7 @@ describe 'Mixin (Qonfig::Configurable)' do
     end
     expect(AnyApplication.config.to_h).to match(
       'env' => { 'GENERIC_VARIABLE' => false },
-      'data' => { 'version' => '2.2.11', 'language' => 'mega_ruby' },
+      'data' => { 'version' => '2.2.11', 'language' => 'mega_ruby' }
     )
 
     any_app.configure(data: { version: '3x3' }) do |conf|
@@ -168,7 +168,7 @@ describe 'Mixin (Qonfig::Configurable)' do
     end
     expect(any_app.config.to_h).to match(
       'env' => { 'GENERIC_VARIABLE' => nil },
-      'data' => { 'version' => '3x3', 'language' => 'ultra_ruby' },
+      'data' => { 'version' => '3x3', 'language' => 'ultra_ruby' }
     )
 
     [AnyApplication, any_app].each do |configurable|

--- a/spec/features/mixin_spec.rb
+++ b/spec/features/mixin_spec.rb
@@ -8,7 +8,7 @@ describe 'Mixin (Qonfig::Configurable)' do
 
     configuration do
       setting :env do
-        load_from_env convert_values: true, prefix: /\Aqonfig_mixin.*\z/i
+        load_from_env convert_values: true, prefix: 'QONFIG_MIXIN_', trim_prefix: true
       end
 
       setting :data do
@@ -29,12 +29,12 @@ describe 'Mixin (Qonfig::Configurable)' do
     any_app = AnyApplication.new
 
     # class has it's own config object
-    expect(AnyApplication.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq(true)
+    expect(AnyApplication.config[:env][:GENERIC_VARIABLE]).to eq(true)
     expect(AnyApplication.config[:data][:version]).to eq(RUBY_VERSION)
     expect(AnyApplication.config[:data][:language]).to eq('ruby')
 
     # instance has it's own config object
-    expect(any_app.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq(true)
+    expect(any_app.config[:env][:GENERIC_VARIABLE]).to eq(true)
     expect(any_app.config[:data][:version]).to eq(RUBY_VERSION)
     expect(any_app.config[:data][:language]).to eq('ruby')
 
@@ -42,16 +42,16 @@ describe 'Mixin (Qonfig::Configurable)' do
     AnyApplication.configure do |conf|
       conf.data.version  = '9.2.0.0'
       conf.data.language = 'jruby'
-      conf[:env][:QONFIG_MIXIN_GENERIC_VARIABLE] = false
+      conf[:env][:GENERIC_VARIABLE] = false
     end
 
     # class config - affected
-    expect(AnyApplication.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq(false)
+    expect(AnyApplication.config[:env][:GENERIC_VARIABLE]).to eq(false)
     expect(AnyApplication.config[:data][:version]).to eq('9.2.0.0')
     expect(AnyApplication.config[:data][:language]).to eq('jruby')
 
     # instance config - not affected
-    expect(any_app.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq(true)
+    expect(any_app.config[:env][:GENERIC_VARIABLE]).to eq(true)
     expect(any_app.config[:data][:version]).to eq(RUBY_VERSION)
     expect(any_app.config[:data][:language]).to eq('ruby')
 
@@ -59,16 +59,16 @@ describe 'Mixin (Qonfig::Configurable)' do
     any_app.configure do |conf|
       conf.data.version = '2.4.1'
       conf.data.language = 'mruby'
-      conf[:env][:QONFIG_MIXIN_GENERIC_VARIABLE] = nil
+      conf[:env][:GENERIC_VARIABLE] = nil
     end
 
     # class config - not affected
-    expect(AnyApplication.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq(false)
+    expect(AnyApplication.config[:env][:GENERIC_VARIABLE]).to eq(false)
     expect(AnyApplication.config[:data][:version]).to eq('9.2.0.0')
     expect(AnyApplication.config[:data][:language]).to eq('jruby')
 
     # instance config - affected
-    expect(any_app.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq(nil)
+    expect(any_app.config[:env][:GENERIC_VARIABLE]).to eq(nil)
     expect(any_app.config[:data][:version]).to eq('2.4.1')
     expect(any_app.config[:data][:language]).to eq('mruby')
 
@@ -78,81 +78,113 @@ describe 'Mixin (Qonfig::Configurable)' do
     inh_app = InheritedApplication.new
 
     # class has it's own config object
-    expect(InheritedApplication.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq(true)
+    expect(InheritedApplication.config[:env][:GENERIC_VARIABLE]).to eq(true)
     expect(InheritedApplication.config[:data][:version]).to eq(RUBY_VERSION)
     expect(InheritedApplication.config[:data][:language]).to eq('ruby')
     expect(InheritedApplication.config[:database][:adapter]).to eq('postgresql')
 
     # instance has it's own config object
-    expect(inh_app.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq(true)
+    expect(inh_app.config[:env][:GENERIC_VARIABLE]).to eq(true)
     expect(inh_app.config[:data][:version]).to eq(RUBY_VERSION)
     expect(inh_app.config[:data][:language]).to eq('ruby')
     expect(inh_app.config[:database][:adapter]).to eq('postgresql')
 
     # configure class-level config object
     InheritedApplication.configure do |conf|
-      conf[:env][:QONFIG_MIXIN_GENERIC_VARIABLE] = '123'
+      conf[:env][:GENERIC_VARIABLE] = '123'
       conf[:data][:version] = '2.2.10'
       conf[:data][:language] = 'super_ruby'
       conf[:database][:adapter] = 'oracle'
     end
 
     # class config - affected
-    expect(InheritedApplication.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq('123')
+    expect(InheritedApplication.config[:env][:GENERIC_VARIABLE]).to eq('123')
     expect(InheritedApplication.config[:data][:version]).to eq('2.2.10')
     expect(InheritedApplication.config[:data][:language]).to eq('super_ruby')
     expect(InheritedApplication.config[:database][:adapter]).to eq('oracle')
 
     # instance config - not affected
-    expect(inh_app.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq(true)
+    expect(inh_app.config[:env][:GENERIC_VARIABLE]).to eq(true)
     expect(inh_app.config[:data][:version]).to eq(RUBY_VERSION)
     expect(inh_app.config[:data][:language]).to eq('ruby')
     expect(inh_app.config[:database][:adapter]).to eq('postgresql')
 
     # configure instance-level config object
     inh_app.configure do |conf|
-      conf[:env][:QONFIG_MIXIN_GENERIC_VARIABLE] = 'mega-blast'
+      conf[:env][:GENERIC_VARIABLE] = 'mega-blast'
       conf[:data][:version] = '3x3'
       conf[:data][:language] = 'ultimate_ruby'
       conf[:database][:adapter] = 'mongodb'
     end
 
     # class config - not affected
-    expect(InheritedApplication.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq('123')
+    expect(InheritedApplication.config[:env][:GENERIC_VARIABLE]).to eq('123')
     expect(InheritedApplication.config[:data][:version]).to eq('2.2.10')
     expect(InheritedApplication.config[:data][:language]).to eq('super_ruby')
     expect(InheritedApplication.config[:database][:adapter]).to eq('oracle')
 
     # instance config - affected
-    expect(inh_app.config[:env][:QONFIG_MIXIN_GENERIC_VARIABLE]).to eq('mega-blast')
+    expect(inh_app.config[:env][:GENERIC_VARIABLE]).to eq('mega-blast')
     expect(inh_app.config[:data][:version]).to eq('3x3')
     expect(inh_app.config[:data][:language]).to eq('ultimate_ruby')
     expect(inh_app.config[:database][:adapter]).to eq('mongodb')
 
     # -- there are no intersections between original and inherited entities --
     expect(any_app.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => nil },
+      'env' => { 'GENERIC_VARIABLE' => nil },
       'data' => { 'version' => '2.4.1', 'language' => 'mruby' }
     )
 
     expect(AnyApplication.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => false },
+      'env' => { 'GENERIC_VARIABLE' => false },
       'data' => { 'version' => '9.2.0.0', 'language' => 'jruby' }
     )
 
     expect(inh_app.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => 'mega-blast' },
+      'env' => { 'GENERIC_VARIABLE' => 'mega-blast' },
       'data' => { 'version' => '3x3', 'language' => 'ultimate_ruby' },
       'database' => { 'adapter' => 'mongodb' }
     )
 
     expect(InheritedApplication.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => '123' },
+      'env' => { 'GENERIC_VARIABLE' => '123' },
       'data' => { 'version' => '2.2.10', 'language' => 'super_ruby' },
       'database' => { 'adapter' => 'oracle' }
     )
 
-    # --- config definitions extends correctly ---
+    # --- configuration with hash / hash + proc
+    AnyApplication.configure(env: { GENERIC_VARIABLE: false }) do |conf|
+      conf.data.version = '2.2.11'
+      conf.data.language = 'mega_ruby'
+    end
+    expect(AnyApplication.config.to_h).to match(
+      'env' => { 'GENERIC_VARIABLE' => false },
+      'data' => { 'version' => '2.2.11', 'language' => 'mega_ruby' },
+    )
+
+    any_app.configure(data: { version: '3x3' }) do |conf|
+      conf.data.language = 'ultra_ruby'
+      conf.env[:GENERIC_VARIABLE] = nil
+    end
+    expect(any_app.config.to_h).to match(
+      'env' => { 'GENERIC_VARIABLE' => nil },
+      'data' => { 'version' => '3x3', 'language' => 'ultra_ruby' },
+    )
+
+    [AnyApplication, any_app].each do |configurable|
+      expect do
+        configurable.configure(env: { nonexistent_key: 100 })
+        binding.pry
+      end.to raise_error(Qonfig::UnknownSettingError)
+      expect do
+        configurable.configure(nonexistent_key: false)
+      end.to raise_error(Qonfig::UnknownSettingError)
+      expect do
+        configurable.configure(env: nil)
+      end.to raise_error(Qonfig::AmbiguousSettingValueError)
+    end
+
+    # --- config definitions extend working correctly ---
     AnyApplication.configuration do
       setting :any_additional, 'any'
     end
@@ -168,26 +200,26 @@ describe 'Mixin (Qonfig::Configurable)' do
     inh_app.config.reload!
 
     expect(any_app.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => true },
+      'env' => { 'GENERIC_VARIABLE' => true },
       'data' => { 'version' => RUBY_VERSION, 'language' => 'ruby' },
       'any_additional' => 'any'
     )
 
     expect(AnyApplication.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => true },
+      'env' => { 'GENERIC_VARIABLE' => true },
       'data' => { 'version' => RUBY_VERSION, 'language' => 'ruby' },
       'any_additional' => 'any'
     )
 
     expect(inh_app.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => true },
+      'env' => { 'GENERIC_VARIABLE' => true },
       'data' => { 'version' => RUBY_VERSION, 'language' => 'ruby' },
       'database' => { 'adapter' => 'postgresql' },
       'inh_additional' => 'inh'
     )
 
     expect(InheritedApplication.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => true },
+      'env' => { 'GENERIC_VARIABLE' => true },
       'data' => { 'version' => RUBY_VERSION, 'language' => 'ruby' },
       'database' => { 'adapter' => 'postgresql' },
       'inh_additional' => 'inh'
@@ -201,26 +233,26 @@ describe 'Mixin (Qonfig::Configurable)' do
     inh_app.config.clear!
 
     expect(any_app.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => nil },
+      'env' => { 'GENERIC_VARIABLE' => nil },
       'data' => { 'version' => nil, 'language' => nil },
       'any_additional' => nil
     )
 
     expect(AnyApplication.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => nil },
+      'env' => { 'GENERIC_VARIABLE' => nil },
       'data' => { 'version' => nil, 'language' => nil },
       'any_additional' => nil
     )
 
     expect(inh_app.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => nil },
+      'env' => { 'GENERIC_VARIABLE' => nil },
       'data' => { 'version' => nil, 'language' => nil },
       'database' => { 'adapter' => nil },
       'inh_additional' => nil
     )
 
     expect(InheritedApplication.config.to_h).to match(
-      'env' => { 'QONFIG_MIXIN_GENERIC_VARIABLE' => nil },
+      'env' => { 'GENERIC_VARIABLE' => nil },
       'data' => { 'version' => nil, 'language' => nil },
       'database' => { 'adapter' => nil },
       'inh_additional' => nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,5 +18,6 @@ require 'pry'
 
 RSpec.configure do |config|
   config.order = :random
+  Kernel.srand config.seed
   config.expect_with(:rspec) { |c| c.syntax = :expect }
 end


### PR DESCRIPTION
It would be nice to have an ability to apply a hash as a configuration option values in this manner:

```ruby
class Config < Qonfig::DataSet
  setting :a do
    setting :b do
      setting :c
      setting :d
    end
  end

  setting :e
  setting :f
end

# partial configuration
Config.new(e: 1, f: 2) do |conf|
  conf.a.b.c = 1
  conf.a.b.d = 2
end

# full configuration
Config.new(a: { b: { c: 1, d: 2 }, e: 3, f: 4)

# proc priority
config = Config.new(e: 33) { |conf| conf.e = 55 }
config.settings.e # => 55

# key does not exist
Config.new(z: 55) # => Qonfig::UnknownSettingError

# nested key does not exist
Config.new(a: { z: 33 }) # => Qonfig::UnknownSettingError

# attempt to override an option that contains nested options
Config.new(a: { b: 55 }) # => Qonfig::AmbiguousSettingValueError
Config.new(a: 30) # => Qonfig::AmbiguousSettingValueError

# and etc
```