### PR TITLE
[json/yaml/self-loaders] treat empty hashes as empty hash values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Changed
+- `expose_yaml`, `load_from_yaml`, `load_from_json` and `load_from_self` treats empty hash (`{}`)
+  as an option with empty hash value (previously treated as a nested setting);
+
 ## [0.7.0] - 2018-10-20
 ### Added
 - `expose_yaml` - a command that provides an ability to define config settings

--- a/lib/qonfig/data_set/class_builder.rb
+++ b/lib/qonfig/data_set/class_builder.rb
@@ -16,9 +16,8 @@ module Qonfig
         def build_from_hash(hash)
           Class.new(Qonfig::DataSet).tap do |data_set_klass|
             hash.each_pair do |key, value|
-              if value.is_a?(Hash)
+              if value.is_a?(Hash) && value.any?
                 sub_data_set_klass = build_from_hash(value)
-
                 data_set_klass.setting(key) { compose sub_data_set_klass }
               else
                 data_set_klass.setting key, value

--- a/spec/features/clear_options_spec.rb
+++ b/spec/features/clear_options_spec.rb
@@ -23,8 +23,7 @@ describe 'Clear options' do
 
       setting :travis do
         load_from_yaml File.expand_path(
-          File.join('..', '..', 'fixtures', 'travis_settings.yml'),
-          Pathname.new(__FILE__).realpath
+          File.join('..', 'fixtures', 'travis_settings.yml'), __dir__
         )
       end
 

--- a/spec/features/expose_yaml_spec.rb
+++ b/spec/features/expose_yaml_spec.rb
@@ -4,8 +4,7 @@ describe 'Expose YAML file' do
   specify 'defines config object by yaml instructions and specific environment settings' do
     class ExposeYAMLConfig < Qonfig::DataSet
       yaml_file_path = File.expand_path(
-        File.join('..', '..', 'fixtures', 'expose_yaml', 'project.yml'),
-        Pathname.new(__FILE__).realpath
+        File.join('..', 'fixtures', 'expose_yaml', 'project.yml'), __dir__
       )
 
       setting :file_name_based do
@@ -60,18 +59,22 @@ describe 'Expose YAML file' do
     expect(settings.file_name_based.test_env.api_mode_enabled).to eq(false)
     expect(settings.file_name_based.test_env.db_driver).to eq('in_memory')
     expect(settings.file_name_based.test_env.logging).to eq(false)
+    expect(settings.file_name_based.test_env.credentials).to eq({})
     # spec/fixtures/expose_yaml/project.production.yaml
     expect(settings.file_name_based.prod_env.api_mode_enabled).to eq(true)
     expect(settings.file_name_based.prod_env.db_driver).to eq('rom')
     expect(settings.file_name_based.prod_env.logging).to eq(true)
+    expect(settings.file_name_based.prod_env.credentials).to eq({})
     # spec/fixtures/expose_yaml/project.development.yml
     expect(settings.file_name_based.dev_env.api_mode_enabled).to eq(true)
     expect(settings.file_name_based.dev_env.db_driver).to eq('sequel')
     expect(settings.file_name_based.dev_env.logging).to eq(false)
+    expect(settings.file_name_based.dev_env.credentials).to eq({})
     # spec/fixtures/expose_yaml/project.staging.yml
     expect(settings.file_name_based.stage_env.api_mode_enabled).to eq(true)
     expect(settings.file_name_based.stage_env.db_driver).to eq('active_record')
     expect(settings.file_name_based.stage_env.logging).to eq(true)
+    expect(settings.file_name_based.stage_env.credentials).to eq({})
 
     # NOTE: environment based expose
     # spec/fixtures/expose_yaml/project.yml (key: 'test')
@@ -79,21 +82,25 @@ describe 'Expose YAML file' do
     expect(settings.env_based.test_env.db_driver).to eq('in_memory')
     expect(settings.env_based.test_env.logging).to eq(false)
     expect(settings.env_based.test_env.throttle_requests).to eq(false)
+    expect(settings.env_based.test_env.credentials).to eq({})
     # spec/fixtures/expose_yaml/project.yaml (key: 'production')
     expect(settings.env_based.prod_env.api_mode_enabled).to eq(true)
     expect(settings.env_based.prod_env.db_driver).to eq('rom')
     expect(settings.env_based.prod_env.logging).to eq(true)
     expect(settings.env_based.prod_env.throttle_requests).to eq(true)
+    expect(settings.env_based.prod_env.credentials).to eq({})
     # spec/fixtures/expose_yaml/project.yml (key: 'development')
     expect(settings.env_based.dev_env.api_mode_enabled).to eq(true)
     expect(settings.env_based.dev_env.db_driver).to eq('sequel')
     expect(settings.env_based.dev_env.logging).to eq(false)
     expect(settings.env_based.dev_env.throttle_requests).to eq(false)
+    expect(settings.env_based.dev_env.credentials).to eq({})
     # spec/fixtures/expose_yaml/project.yml (key: 'staging')
     expect(settings.env_based.stage_env.api_mode_enabled).to eq(true)
     expect(settings.env_based.stage_env.db_driver).to eq('active_record')
     expect(settings.env_based.stage_env.logging).to eq(true)
     expect(settings.env_based.stage_env.throttle_requests).to eq(true)
+    expect(settings.env_based.stage_env.credentials).to eq({})
   end
 
   describe 'failures and inconsistent situations' do
@@ -102,8 +109,7 @@ describe 'Expose YAML file' do
         expect do
           Class.new(Qonfig::DataSet) do
             expose_yaml File.expand_path(
-              File.join('..', '..', 'fixtures', 'expose_yaml', 'project.yml'),
-              Pathname.new(__FILE__).realpath
+              File.join('..', 'fixtures', 'expose_yaml', 'project.yml'), __dir__
             ), via: :env_key, env: Object.new
           end
         end.to raise_error(Qonfig::ArgumentError)
@@ -113,8 +119,7 @@ describe 'Expose YAML file' do
         expect do
           Class.new(Qonfig::DataSet) do
             expose_yaml File.expand_path(
-              File.join('..', '..', 'fixtures', 'expose_yaml', 'project.yml'),
-              Pathname.new(__FILE__).realpath
+              File.join('..', 'fixtures', 'expose_yaml', 'project.yml'), __dir__
             ), via: :env_key, env: ''
           end
         end.to raise_error(Qonfig::ArgumentError)
@@ -124,8 +129,7 @@ describe 'Expose YAML file' do
         expect do
           Class.new(Qonfig::DataSet) do
             expose_yaml File.expand_path(
-              File.join('..', '..', 'fixtures', 'expose_yaml', 'project.yml'),
-              Pathname.new(__FILE__).realpath
+              File.join('..', 'fixtures', 'expose_yaml', 'project.yml'), __dir__
             ), via: :auto, env: :production
           end
         end.to raise_error(Qonfig::ArgumentError)
@@ -141,8 +145,7 @@ describe 'Expose YAML file' do
 
         class IncompatibleEnvBasedYAMLConfig < Qonfig::DataSet
           expose_yaml File.expand_path(
-            File.join('..', '..', 'fixtures', 'expose_yaml', 'incompatible_structure.yml'),
-            Pathname.new(__FILE__).realpath
+            File.join('..', 'fixtures', 'expose_yaml', 'incompatible_structure.yml'), __dir__
           ), via: :env_key, env: :staging
         end
 
@@ -152,8 +155,7 @@ describe 'Expose YAML file' do
 
         class CompatibleEnvBasedYAMLConfig < Qonfig::DataSet
           expose_yaml File.expand_path(
-            File.join('..', '..', 'fixtures', 'expose_yaml', 'incompatible_structure.yml'),
-            Pathname.new(__FILE__).realpath
+            File.join('..', 'fixtures', 'expose_yaml', 'incompatible_structure.yml'), __dir__
           ), via: :env_key, env: :test
         end
 
@@ -169,15 +171,13 @@ describe 'Expose YAML file' do
           class NoFileNonStrictExposeYAMLConfig < Qonfig::DataSet
             setting :non_strict_by_file do
               expose_yaml File.expand_path(
-                File.join('..', '..', 'fixtures', 'expose_yaml', 'nonexistent.yml'),
-                Pathname.new(__FILE__).realpath
+                File.join('..', 'fixtures', 'expose_yaml', 'nonexistent.yml'), __dir__
               ), strict: false, via: :file_name, env: :development
             end
 
             setting :non_strict_by_env do
               expose_yaml File.expand_path(
-                File.join('..', '..', 'fixtures', 'expose_yaml', 'nonexistent.yml'),
-                Pathname.new(__FILE__).realpath
+                File.join('..', 'fixtures', 'expose_yaml', 'nonexistent.yml'), __dir__
               ), strict: false, via: :env_key, env: :development
             end
           end
@@ -191,15 +191,13 @@ describe 'Expose YAML file' do
           class NoEnvKeyNonStrictExposeYAMLConfig < Qonfig::DataSet
             setting :non_strict_by_file do
               expose_yaml File.expand_path(
-                File.join('..', '..', 'fixtures', 'expose_yaml', 'project.yml'),
-                Pathname.new(__FILE__).realpath
+                File.join('..', 'fixtures', 'expose_yaml', 'project.yml'), __dir__
               ), strict: false, via: :file_name, env: :nonexistent
             end
 
             setting :non_strict_by_env do
               expose_yaml File.expand_path(
-                File.join('..', '..', 'fixtures', 'expose_yaml', 'project.yml'),
-                Pathname.new(__FILE__).realpath
+                File.join('..', 'fixtures', 'expose_yaml', 'project.yml'), __dir__
               ), strict: false, via: :env_key, env: :nonexistent
             end
           end
@@ -217,15 +215,13 @@ describe 'Expose YAML file' do
           # NOTE: file does not exist
           class StrictFileViaFileNameConfig < Qonfig::DataSet
             expose_yaml File.expand_path(
-              File.join('..', '..', 'fixtures', 'expose_yaml', 'nonexistent.yml'),
-              Pathname.new(__FILE__).realpath
+              File.join('..', 'fixtures', 'expose_yaml', 'nonexistent.yml'), __dir__
             ), via: :file_name, env: :production
           end
           # NOTE: file does not exist
           class StrictFileViaEnvKeyConfig < Qonfig::DataSet
             expose_yaml File.expand_path(
-              File.join('..', '..', 'fixtures', 'expose_yaml', 'nonexistent.yml'),
-              Pathname.new(__FILE__).realpath
+              File.join('..', 'fixtures', 'expose_yaml', 'nonexistent.yml'), __dir__
             ), via: :env_key, env: :production
           end
 
@@ -238,8 +234,7 @@ describe 'Expose YAML file' do
           #   - file: spec/fixtures/expose_yaml/project.yml
           class NonExistentEnvKeyConfig < Qonfig::DataSet
             expose_yaml File.expand_path(
-              File.join('..', '..', 'fixtures', 'expose_yaml', 'project.yml'),
-              Pathname.new(__FILE__).realpath
+              File.join('..', 'fixtures', 'expose_yaml', 'project.yml'), __dir__
             ), via: :env_key, env: :nonexistent
           end
 

--- a/spec/features/load_from_json_spec.rb
+++ b/spec/features/load_from_json_spec.rb
@@ -4,14 +4,18 @@ describe 'Load from JSON' do
   specify 'defines config object by json instructions' do
     class JSONBasedConfig < Qonfig::DataSet
       load_from_json File.expand_path(
-        File.join('..', '..', 'fixtures', 'json_object_sample.json'),
-        Pathname.new(__FILE__).realpath
+        File.join('..', 'fixtures', 'json_object_sample.json'), __dir__
       )
 
       setting :nested do
         load_from_json File.expand_path(
-          File.join('..', '..', 'fixtures', 'json_object_sample.json'),
-          Pathname.new(__FILE__).realpath
+          File.join('..', 'fixtures', 'json_object_sample.json'), __dir__
+        )
+      end
+
+      setting :with_empty_objects do
+        load_from_json File.expand_path(
+          File.join('..', 'fixtures', 'json_with_empty_object.json'), __dir__
         )
       end
     end
@@ -28,14 +32,16 @@ describe 'Load from JSON' do
       expect(conf.nested.rubySettings.allowedVersions).to eq(['2.3', '2.4.2', '1.9.8'])
       expect(conf.nested.rubySettings.gitLink).to eq(nil)
       expect(conf.nested.rubySettings.withAdditionals).to eq(false)
+
+      expect(conf.with_empty_objects.requirements).to eq({})
+      expect(conf.with_empty_objects.credentials.excluded).to eq({})
     end
   end
 
   specify 'fails when json object has non-hash-like structure' do
     class IncompatibleJSONConfig < Qonfig::DataSet
       load_from_json File.expand_path(
-        File.join('..', '..', 'fixtures', 'json_array_sample.json'),
-        Pathname.new(__FILE__).realpath
+        File.join('..', 'fixtures', 'json_array_sample.json'), __dir__
       )
     end
 

--- a/spec/features/load_from_self/with_erb_instructions_spec.rb
+++ b/spec/features/load_from_self/with_erb_instructions_spec.rb
@@ -10,10 +10,12 @@ describe 'Load from self (hash-like __END__ data representation with ERB inserts
       expect(conf.defaults.host).to eq('localhost')
       expect(conf.defaults.user).to eq('0exp')
       expect(conf.defaults.password).to eq('password4')
+      expect(conf.defaults.credentials).to eq({})
 
       expect(conf.staging.host).to eq('yandex.ru')
       expect(conf.staging.user).to eq('0exp')
       expect(conf.staging.password).to eq('password4')
+      expect(conf.staging.credentials).to eq({})
     end
   end
 end
@@ -24,6 +26,7 @@ defaults: &defaults
   host: localhost
   user: <%= '0exp' %>
   password: <%= "password#{(2 * 2)}" %>
+  credentials: <%= {} %>
 
 staging:
   <<: *defaults

--- a/spec/features/load_from_self/with_hash_like_data_representation_spec.rb
+++ b/spec/features/load_from_self/with_hash_like_data_representation_spec.rb
@@ -14,6 +14,7 @@ describe 'Load from self (hash-like __END__ data representation)' do
       # access via method
       expect(conf.secret_key).to eq('top-mega-secret')
       expect(conf.api_host).to eq('super.puper-google.com')
+      expect(conf.requirements).to eq({})
       expect(conf.connection_timeout.seconds).to eq(10)
       expect(conf.connection_timeout.enabled).to eq(false)
       expect(conf.defaults.port).to eq(12_345)
@@ -24,6 +25,7 @@ describe 'Load from self (hash-like __END__ data representation)' do
       # access via index
       expect(conf['secret_key']).to eq('top-mega-secret')
       expect(conf['api_host']).to eq('super.puper-google.com')
+      expect(conf['requirements']).to eq({})
       expect(conf[:connection_timeout]['seconds']).to eq(10)
       expect(conf[:connection_timeout]['enabled']).to eq(false)
       expect(conf['defaults']['port']).to eq(12_345)
@@ -31,13 +33,16 @@ describe 'Load from self (hash-like __END__ data representation)' do
       expect(conf['staging']['port']).to eq(12_345)
       expect(conf['staging']['host']).to eq('google.kek')
 
+
       expect(conf.with_nesting.secret_key).to eq('top-mega-secret')
       expect(conf.with_nesting.api_host).to eq('super.puper-google.com')
       expect(conf.with_nesting.connection_timeout.seconds).to eq(10)
       expect(conf.with_nesting.connection_timeout.enabled).to eq(false)
+      expect(conf.with_nesting.requirements).to eq({})
 
       expect(conf[:with_nesting]['secret_key']).to eq('top-mega-secret')
       expect(conf[:with_nesting]['api_host']).to eq('super.puper-google.com')
+      expect(conf[:with_nesting][:requirements]).to eq({})
       expect(conf[:with_nesting][:connection_timeout]['seconds']).to eq(10)
       expect(conf[:with_nesting][:connection_timeout]['enabled']).to eq(false)
     end
@@ -56,6 +61,7 @@ staging:
 
 secret_key: top-mega-secret
 api_host: super.puper-google.com
+requirements: {}
 :connection_timeout:
    seconds: 10
    enabled: false

--- a/spec/features/load_from_yaml_spec.rb
+++ b/spec/features/load_from_yaml_spec.rb
@@ -4,28 +4,30 @@ describe 'Load from YAML' do
   specify 'defines config object by yaml instructions' do
     class CISettings < Qonfig::DataSet
       load_from_yaml File.expand_path(
-        File.join('..', '..', 'fixtures', 'shared_settings_with_aliases.yml'),
-        Pathname.new(__FILE__).realpath
+        File.join('..', 'fixtures', 'shared_settings_with_aliases.yml'), __dir__
       )
 
       setting :travis do
         load_from_yaml File.expand_path(
-          File.join('..', '..', 'fixtures', 'travis_settings.yml'),
-          Pathname.new(__FILE__).realpath
+          File.join('..', 'fixtures', 'travis_settings.yml'), __dir__
         )
       end
 
       setting :rubocop do
         load_from_yaml File.expand_path(
-          File.join('..', '..', 'fixtures', 'rubocop_settings.yml'),
-          Pathname.new(__FILE__).realpath
+          File.join('..', 'fixtures', 'rubocop_settings.yml'), __dir__
         )
       end
 
       setting :with_erb do
         load_from_yaml File.expand_path(
-          File.join('..', '..', 'fixtures', 'with_erb_instructions.yml'),
-          Pathname.new(__FILE__).realpath
+          File.join('..', 'fixtures', 'with_erb_instructions.yml'), __dir__
+        )
+      end
+
+      setting :with_empty_hash do
+        load_from_yaml File.expand_path(
+          File.join('..', 'fixtures', 'with_empty_hash.yml'), __dir__
         )
       end
     end
@@ -54,14 +56,18 @@ describe 'Load from YAML' do
       expect(conf['with_erb']['user']).to eq('D@iVeR')
       expect(conf['with_erb']['max_auth_count']).to eq(2)
       expect(conf['with_erb']['ruby_version']).to eq(RUBY_VERSION)
+
+      # with_empty_hash.yml
+      expect(conf['with_empty_hash']['settings']).to eq({})
+      expect(conf['with_empty_hash']['another_settings']['option_a']).to eq({})
+      expect(conf['with_empty_hash']['another_settings']['option_b']).to eq(1)
     end
   end
 
   specify 'fails when yaml settings is not represented as a hash' do
     class IncompatibleYAMLConfig < Qonfig::DataSet
       load_from_yaml File.expand_path(
-        File.join('..', '..', 'fixtures', 'array_settings.yml'),
-        Pathname.new(__FILE__).realpath
+        File.join('..', 'fixtures', 'array_settings.yml'), __dir__
       )
     end
 

--- a/spec/fixtures/expose_yaml/project.development.yml
+++ b/spec/fixtures/expose_yaml/project.development.yml
@@ -1,3 +1,4 @@
 api_mode_enabled: true
 db_driver: sequel
 logging: false
+credentials: {}

--- a/spec/fixtures/expose_yaml/project.production.yml
+++ b/spec/fixtures/expose_yaml/project.production.yml
@@ -1,3 +1,4 @@
 api_mode_enabled: true
 db_driver: rom
 logging: true
+credentials: {}

--- a/spec/fixtures/expose_yaml/project.staging.yml
+++ b/spec/fixtures/expose_yaml/project.staging.yml
@@ -1,3 +1,4 @@
 api_mode_enabled: true
 db_driver: active_record
 logging: true
+credentials: {}

--- a/spec/fixtures/expose_yaml/project.test.yml
+++ b/spec/fixtures/expose_yaml/project.test.yml
@@ -1,3 +1,4 @@
 api_mode_enabled: false
 db_driver: in_memory
 logging: false
+credentials: {}

--- a/spec/fixtures/expose_yaml/project.yml
+++ b/spec/fixtures/expose_yaml/project.yml
@@ -3,6 +3,7 @@ default: &default
   logging: true
   db_driver: in_memory
   throttle_requests: false
+  credentials: {}
 
 development:
   <<: *default

--- a/spec/fixtures/json_with_empty_object.json
+++ b/spec/fixtures/json_with_empty_object.json
@@ -1,0 +1,6 @@
+{
+  "requirements": {},
+  "credentials": {
+    "excluded": {}
+  }
+}

--- a/spec/fixtures/with_empty_hash.yml
+++ b/spec/fixtures/with_empty_hash.yml
@@ -1,0 +1,4 @@
+settings: {}
+another_settings:
+  option_a: {}
+  option_b: 1


### PR DESCRIPTION
YAML (same for json):

```yml
requirements: {}
```

Before:
```ruby
config.settings.requirements
# => #<Qonfig::Settings:0x000...> (nested settings without options)
```
Now:
```ruby
config.settings.requirements
# => {}
```