### PR TITLE
Fix typo in qonfig.gemspec

### DIFF
--- a/qonfig.gemspec
+++ b/qonfig.gemspec
@@ -1,4 +1,4 @@
-# codning: utf-8
+# coding: utf-8
 # frozen_string_literal: true
 
 lib = File.expand_path('lib', __dir__)


### PR DESCRIPTION
Hi! I've noticed there's a small typo in your gem specification.