### PR TITLE
[dot-notation] Support for dot-notation in key/subset/slice/dig and etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- **FINALY**: support for dot-notation in `in `#key?`, `#option?`, `#setting?`, `#dig`, `#subset`, `#slice`, `#slice_value`, `[]`;
 - `freeze_state!` DSL directive (all your configs becomes frozen after being instantiated immediately);
 - Global `Qonfig::FrozenError` error for `frozen`-based exceptions;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- **FINALY**: support for dot-notation in `in `#key?`, `#option?`, `#setting?`, `#dig`, `#subset`, `#slice`, `#slice_value`, `[]`;
+- **FINALY**: support for dot-notation in `#key?`, `#option?`, `#setting?`, `#dig`, `#subset`, `#slice`, `#slice_value`, `[]`;
 - `freeze_state!` DSL directive (all your configs becomes frozen after being instantiated immediately);
 - Global `Qonfig::FrozenError` error for `frozen`-based exceptions;
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Qonfig &middot; [![Gem Version](https://badge.fury.io/rb/qonfig.svg)](https://badge.fury.io/rb/qonfig) [![Build Status](https://travis-ci.org/0exp/qonfig.svg?branch=master)](https://travis-ci.org/0exp/qonfig) [![Coverage Status](https://coveralls.io/repos/github/0exp/qonfig/badge.svg?branch=master)](https://coveralls.io/github/0exp/qonfig?branch=master)
 
 Config. Defined as a class. Used as an instance. Support for inheritance and composition.
-Lazy instantiation. Thread-safe. Command-style DSL. Validation layer. Support for **dot-notation**!
+Lazy instantiation. Thread-safe. Command-style DSL. Validation layer. **DOT-NOTATION**!
 Support for **YAML**, **TOML**, **JSON**, **\_\_END\_\_**, **ENV**.
 Extremely simple to define. Extremely simple to use. That's all? **NOT** :)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Qonfig &middot; [![Gem Version](https://badge.fury.io/rb/qonfig.svg)](https://badge.fury.io/rb/qonfig) [![Build Status](https://travis-ci.org/0exp/qonfig.svg?branch=master)](https://travis-ci.org/0exp/qonfig) [![Coverage Status](https://coveralls.io/repos/github/0exp/qonfig/badge.svg?branch=master)](https://coveralls.io/github/0exp/qonfig?branch=master)
 
 Config. Defined as a class. Used as an instance. Support for inheritance and composition.
-Lazy instantiation. Thread-safe. Command-style DSL. Validation layer. Support for **YAML**, **TOML**, **JSON**, **\_\_END\_\_**, **ENV**.
+Lazy instantiation. Thread-safe. Command-style DSL. Validation layer. Support for **dot-notation**!
+Support for **YAML**, **TOML**, **JSON**, **\_\_END\_\_**, **ENV**.
 Extremely simple to define. Extremely simple to use. That's all? **NOT** :)
 
 ## Installation
@@ -138,6 +139,8 @@ config.settings.enable_graphql # => false
 
 #### access via index-method []
 
+- without dot-notation:
+
 ```ruby
 # get option value via index (with indifferent (string / symbol / mixed) access)
 config.settings[:project_id] # => nil
@@ -158,7 +161,19 @@ config[:project_id] # => nil
 config[:enable_graphql] # => false
 ```
 
+- with dot-notation:
+
+```ruby
+config.settings['vendor_api.host'] # => 'app.service.com'
+config.settings['vendor_api.user'] # => 'test_user'
+
+config.['vendor_api.host'] # => 'app.service.com'
+config.['vendor_api.user'] # => 'test_user'
+```
+
 #### .dig
+
+- without dot-notation:
 
 ```ruby
 # get option value in Hash#dig manner (and fail when the required key does not exist);
@@ -166,7 +181,16 @@ config.dig(:vendor_api, :host) # => 'app.service.com' # (key exists)
 config.dig(:vendor_api, :port) # => Qonfig::UnknownSettingError # (key does not exist)
 ```
 
+- with dot-notation:
+
+```ruby
+config.dig('vendor_api.host') # => 'app.service.com' # (key exists)
+config.dig('vendor_api.port') # => Qonfig::UnknownSettingError # (key does not exist)
+```
+
 #### .slice
+
+- without dot-notation:
 
 ```ruby
 # get a hash slice of setting options (and fail when the required key does not exist);
@@ -176,7 +200,17 @@ config.slice(:project_api) # => Qonfig::UnknownSettingError # (key does not exis
 config.slice(:vendor_api, :port) # => Qonfig::UnknownSettingError # (key does not exist)
 ```
 
+- with dot-notation:
+
+```ruby
+config.slice('vendor_api.user') # => { 'user' => 'test_user' }
+config.slice('vendor_api.port') # => Qonfig::UnknownSettingError # (key does not exist)
+```
+
+
 #### .slice_value
+
+- without dot-notaiton:
 
 ```ruby
 # get value from the slice of setting options using the given key set
@@ -188,7 +222,16 @@ config.slice_value(:project_api) # => Qonfig::UnknownSettingError # (key does no
 config.slice_value(:vendor_api, :port) # => Qonfig::UnknownSettingError # (key does not exist)
 ```
 
+- with dot-notation:
+
+```ruby
+config.slice_value('vendor_api.user') # => 'test_user'
+config.slice_value('vendor_api.port') # => Qonfig::UnknownSettingError # (key does not exist)
+```
+
 #### .subset
+
+- without dot-notation:
 
 ```ruby
 # - get a subset (a set of sets) of config settings represented as a hash;
@@ -198,6 +241,13 @@ config.subet(:vendor_api, :enable_graphql)
 # => { 'vendor_api' => { 'user' => ..., 'host' => ... }, 'enable_graphql' => false }
 
 config.subset(:project_id, [:vendor_api, :host], [:credentials, :user, :login])
+# => { 'project_id' => nil, 'host' => 'app.service.com', 'login' => 'D@iVeR' }
+```
+
+- with dot-notation:
+
+```ruby
+config.subset('project_id', 'vendor_api.host', 'credentials.user.login')
 # => { 'project_id' => nil, 'host' => 'app.service.com', 'login' => 'D@iVeR' }
 ```
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ config[:enable_graphql] # => false
 config.settings['vendor_api.host'] # => 'app.service.com'
 config.settings['vendor_api.user'] # => 'test_user'
 
-config.['vendor_api.host'] # => 'app.service.com'
-config.['vendor_api.user'] # => 'test_user'
+config['vendor_api.host'] # => 'app.service.com'
+config['vendor_api.user'] # => 'test_user'
 ```
 
 #### .dig

--- a/lib/qonfig/errors.rb
+++ b/lib/qonfig/errors.rb
@@ -41,6 +41,12 @@ module Qonfig
 
   # @see Qonfig::Settings
   #
+  # @api private
+  # @since 0.19.0
+  StrangeThingsError = Class.new(Error)
+
+  # @see Qonfig::Settings
+  #
   # @api public
   # @since 0.2.0
   AmbiguousSettingValueError = Class.new(Error)

--- a/spec/features/dot_notation_spec.rb
+++ b/spec/features/dot_notation_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+describe 'Dot-notation' do
+  let(:config) do
+    config = Qonfig::DataSet.build do
+      setting :kek do
+        setting :pek do
+          setting :cheburek, 'test'
+        end
+
+        setting :frek do
+          setting :jek do
+            setting :bek, 123_456
+          end
+        end
+      end
+    end
+  end
+
+  specify '#key? / #option? / #setting?' do
+    expect(config.key?('kek.pek.cheburek')).to eq(true)
+    expect(config.key?('kek.pek')).to eq(true)
+    expect(config.key?('kek')).to eq(true)
+    expect(config.key?('kek.cheburek.pek')).to eq(false)
+    expect(config.key?('kek.cheburek')).to eq(false)
+
+    expect(config.option?('kek.pek.cheburek')).to eq(true)
+    expect(config.option?('kek.pek')).to eq(true)
+    expect(config.option?('kek')).to eq(true)
+    expect(config.option?('kek.cheburek.pek')).to eq(false)
+    expect(config.option?('kek.cheburek')).to eq(false)
+
+    expect(config.setting?('kek.pek.cheburek')).to eq(true)
+    expect(config.setting?('kek.pek')).to eq(true)
+    expect(config.setting?('kek')).to eq(true)
+    expect(config.setting?('kek.cheburek.pek')).to eq(false)
+    expect(config.setting?('kek.cheburek')).to eq(false)
+  end
+
+  specify '#dig' do
+    expect(config.dig('kek.pek.cheburek')).to eq('test')
+    expect(config.dig('kek.pek')).to be_a(Qonfig::Settings)
+    expect(config.dig('kek')).to be_a(Qonfig::Settings)
+
+    expect { config.dig('kek.pek.ululek') }.to raise_error(Qonfig::UnknownSettingError)
+    expect { config.dig('kek.ululek') }.to raise_error(Qonfig::UnknownSettingError)
+    expect { config.dig('ululek') }.to raise_error(Qonfig::UnknownSettingError)
+  end
+
+  specify '#subset' do
+    expect(config.subset('kek', 'kek.frek')).to match(
+      'kek' => {
+        'frek' => { 'jek' => { 'bek' => 123456 } },
+        'pek' => { 'cheburek'=>'test' }
+      },
+      'frek' => {
+        'jek' => { 'bek' => 123_456 }
+      },
+    )
+
+    expect do
+      config.subset('kek', 'kek.frek', 'kek.lel')
+    end.to raise_error(Qonfig::UnknownSettingError)
+  end
+
+  specify '#slice' do
+    expect(config.slice('kek.pek')).to match('pek' => { 'cheburek' => 'test' })
+    expect(config.slice('kek.frek')).to match('frek' => { 'jek' => { 'bek' => 123_456 } })
+
+    expect { config.slice('lel') }.to raise_error(Qonfig::UnknownSettingError)
+    expect { config.slice('kek.lek') }.to raise_error(Qonfig::UnknownSettingError)
+  end
+
+  specify '#slice_value' do
+    expect(config.slice_value('kek.pek.cheburek')).to eq('test')
+    expect(config.slice_value('kek.pek')).to match('cheburek' => 'test')
+    expect(config.slice_value('kek.frek')).to match('jek' => { 'bek' => 123_456 })
+
+    expect { config.slice_value('kek.pek.lelek') }.to raise_error(Qonfig::UnknownSettingError)
+    expect { config.slice_value('kek.frek.bek') }.to raise_error(Qonfig::UnknownSettingError)
+    expect { config.slice_value('lel') }.to raise_error(Qonfig::UnknownSettingError)
+  end
+
+  specify '#[]' do
+    expect(config['kek.pek.cheburek']).to eq('test')
+    expect(config['kek.pek']).to be_a(Qonfig::Settings)
+    expect(config['kek.pek']['cheburek']).to eq('test')
+    expect(config['kek']['frek.jek']['bek']).to eq(123_456)
+
+    expect { config['kek.pek.lelek'] }.to raise_error(Qonfig::UnknownSettingError)
+    expect { config['kek.frek']['bek'] }.to raise_error(Qonfig::UnknownSettingError)
+    expect { config['lel'] }.to raise_error(Qonfig::UnknownSettingError)
+  end
+end


### PR DESCRIPTION
Closes #87 

---

- see `CHANGELOG.md`
- see `README.md`

---

Synopsis:

```ruby
class Config < Qonfig::DataSet
  setting :api do 
     setting :server do
         setting :provider, 'aws'
      end
   end
end

config = Config.new

# NOW YOU CAN DO THIS!!!:
config['api.server.provider'] # => 'aws'
config.slice('api.server.provider') # => { 'provider' => 'aws' }
config.slice_value('api.server.provider') # => 'aws'
config.subset('api.server', 'api.server.provider') # => { 'server' => { 'provider' => 'aws' }, 'provider' => 'aws' }
config.dig('api.server.provider') # => 'aws'
config.key?('api.server.provder') # => true
config.key?('logger') # => false
```