### PR TITLE
[setting re-definition DSL] Full re-definition of existing setting (additional DSL command "re_setting")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Extended **Validation API**: you can define your own predefined validators via `.define_validator(name, &validation)` directive;
+- `re_setting` - a special DSL command method that fully redefines existing settings (redefines existing settings instead of reopening them);
 
 ## [0.19.1] - 2019-11-29
 ### Changed

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ require 'qonfig'
 ### Definition and Access
 
 - `setting(name, value)` - define setting with corresponding name and value;
-- `setting(name) { ... }` - define nested settings OR reopen existing nested setting and define some new nested settings;
+- `setting(name) { setting(name, value); ... }` - define nested settings OR reopen existing nested setting and define some new nested settings;
 - `re_setting(name, value)`, `re_setting(name) { ... }` - re-define existing setting (or define new if the original does not exist);
 - accessing: [access via method](#access-via-method), [access via index-method \[\]](#access-via-index-method-),
   [.dig](#dig), [.slice](#slice), [.slice_value](#slice_value), [.subset](#subset);

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ require 'qonfig'
 
 - `setting(name, value)` - define setting with corresponding name and value;
 - `setting(name) { ... }` - define nested settings OR reopen existing nested setting and define some new nested settings;
-- `re_setting(name, value)`. `re_setting(name) { ... }` - re-define existing setting in `setting` method manner;
+- `re_setting(name, value)`. `re_setting(name) { ... }` - re-define existing setting in `setting` method manner (or define new setting if the original setting does not exist);
 
 ```ruby
 # --- definition ---

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ require 'qonfig'
 
 - `setting(name, value)` - define setting with corresponding name and value;
 - `setting(name) { ... }` - define nested settings OR reopen existing nested setting and define some new nested settings;
-- `re_setting(name, value)`. `re_setting(name) { ... }` - re-define existing setting (or define new setting if the original setting does not exist);
+- `re_setting(name, value)`, `re_setting(name) { ... }` - re-define existing setting (or define new if the original does not exist);
 
 ```ruby
 # --- definition ---

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ require 'qonfig'
 - `setting(name, value)` - define setting with corresponding name and value;
 - `setting(name) { ... }` - define nested settings OR reopen existing nested setting and define some new nested settings;
 - `re_setting(name, value)`, `re_setting(name) { ... }` - re-define existing setting (or define new if the original does not exist);
+- accessing: [access via method](#access-via-method), [access via index-method \[\]](#access-via-index-method-),
+  [.dig](#dig), [.slice](#slice), [.slice_value](#slice_value), [.subset](#subset);
 
 ```ruby
 # --- definition ---

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ require 'qonfig'
 
 ### Definition and Access
 
+- `setting(name, value)` - define setting with corresponding name and value;
+- `setting(name) { ... }` - define nested settings OR reopen existing nested setting and define some new nested settings;
+- `re_setting(name, value)`. `re_setting(name) { ... }` - re-define existing setting in `setting` method manner;
+
 ```ruby
 # --- definition ---
 class Config < Qonfig::DataSet
@@ -107,14 +111,20 @@ class Config < Qonfig::DataSet
 
   # nested setting
   setting :vendor_api do
-    setting :host, 'app.service.com'
+    setting :host, 'vendor.service.com'
   end
 
   setting :enable_graphql, false
 
   # nested setting reopening
   setting :vendor_api do
-    setting :user, 'test_user'
+    setting :user, 'simple_user'
+  end
+
+  # re-definition of existing setting (drop the old - make the new)
+  re_setting :vendor_api do
+    setting :domain, 'api.service.com'
+    setting :login, 'test_user'
   end
 
   # deep nesting
@@ -134,8 +144,8 @@ config = Config.new # your configuration object instance
 ```ruby
 # get option value via method
 config.settings.project_id # => nil
-config.settings.vendor_api.host # => 'app.service.com'
-config.settings.vendor_api.user # => 'test_user'
+config.settings.vendor_api.domain # => 'app.service.com'
+config.settings.vendor_api.login # => 'test_user'
 config.settings.enable_graphql # => false
 ```
 
@@ -146,14 +156,14 @@ config.settings.enable_graphql # => false
 ```ruby
 # get option value via index (with indifferent (string / symbol / mixed) access)
 config.settings[:project_id] # => nil
-config.settings[:vendor_api][:host] # => 'app.service.com'
-config.settings[:vendor_api][:user] # => 'test_user'
+config.settings[:vendor_api][:domain] # => 'app.service.com'
+config.settings[:vendor_api][:login] # => 'test_user'
 config.settings[:enable_graphql] # => false
 
 # get option value via index (with indifferent (string / symbol / mixed) access)
 config.settings['project_id'] # => nil
-config.settings['vendor_api']['host'] # => 'app.service.com'
-config.settings['vendor_api']['user'] # => 'test_user'
+config.settings['vendor_api']['domain'] # => 'app.service.com'
+config.settings['vendor_api']['login'] # => 'test_user'
 config.settings['enable_graphql'] # => false
 
 # get option value directly via index (with indifferent access)
@@ -166,11 +176,11 @@ config[:enable_graphql] # => false
 - with dot-notation:
 
 ```ruby
-config.settings['vendor_api.host'] # => 'app.service.com'
-config.settings['vendor_api.user'] # => 'test_user'
+config.settings['vendor_api.domain'] # => 'app.service.com'
+config.settings['vendor_api.login'] # => 'test_user'
 
-config['vendor_api.host'] # => 'app.service.com'
-config['vendor_api.user'] # => 'test_user'
+config['vendor_api.domain'] # => 'app.service.com'
+config['vendor_api.login'] # => 'test_user'
 ```
 
 #### .dig
@@ -179,15 +189,15 @@ config['vendor_api.user'] # => 'test_user'
 
 ```ruby
 # get option value in Hash#dig manner (and fail when the required key does not exist);
-config.dig(:vendor_api, :host) # => 'app.service.com' # (key exists)
-config.dig(:vendor_api, :port) # => Qonfig::UnknownSettingError # (key does not exist)
+config.dig(:vendor_api, :domain) # => 'app.service.com' # (key exists)
+config.dig(:vendor_api, :login) # => Qonfig::UnknownSettingError # (key does not exist)
 ```
 
 - with dot-notation:
 
 ```ruby
-config.dig('vendor_api.host') # => 'app.service.com' # (key exists)
-config.dig('vendor_api.port') # => Qonfig::UnknownSettingError # (key does not exist)
+config.dig('vendor_api.domain') # => 'app.service.com' # (key exists)
+config.dig('vendor_api.login') # => Qonfig::UnknownSettingError # (key does not exist)
 ```
 
 #### .slice
@@ -196,8 +206,8 @@ config.dig('vendor_api.port') # => Qonfig::UnknownSettingError # (key does not e
 
 ```ruby
 # get a hash slice of setting options (and fail when the required key does not exist);
-config.slice(:vendor_api) # => { 'vendor_api' => { 'host' => 'app_service', 'user' => 'test_user' } }
-config.slice(:vendor_api, :user) # => { 'user' => 'test_user' }
+config.slice(:vendor_api) # => { 'vendor_api' => { 'domain' => 'app_service', 'login' => 'test_user' } }
+config.slice(:vendor_api, :login) # => { 'login' => 'test_user' }
 config.slice(:project_api) # => Qonfig::UnknownSettingError # (key does not exist)
 config.slice(:vendor_api, :port) # => Qonfig::UnknownSettingError # (key does not exist)
 ```
@@ -205,7 +215,7 @@ config.slice(:vendor_api, :port) # => Qonfig::UnknownSettingError # (key does no
 - with dot-notation:
 
 ```ruby
-config.slice('vendor_api.user') # => { 'user' => 'test_user' }
+config.slice('vendor_api.login') # => { 'loign' => 'test_user' }
 config.slice('vendor_api.port') # => Qonfig::UnknownSettingError # (key does not exist)
 ```
 
@@ -218,8 +228,8 @@ config.slice('vendor_api.port') # => Qonfig::UnknownSettingError # (key does not
 # get value from the slice of setting options using the given key set
 # (and fail when the required key does not exist) (works in slice manner);
 
-config.slice_value(:vendor_api) # => { 'host' => 'app_service', 'user' => 'test_user' }
-config.slice_value(:vendor_api, :user) # => 'test_user'
+config.slice_value(:vendor_api) # => { 'domain' => 'app_service', 'login' => 'test_user' }
+config.slice_value(:vendor_api, :login) # => 'test_user'
 config.slice_value(:project_api) # => Qonfig::UnknownSettingError # (key does not exist)
 config.slice_value(:vendor_api, :port) # => Qonfig::UnknownSettingError # (key does not exist)
 ```
@@ -227,7 +237,7 @@ config.slice_value(:vendor_api, :port) # => Qonfig::UnknownSettingError # (key d
 - with dot-notation:
 
 ```ruby
-config.slice_value('vendor_api.user') # => 'test_user'
+config.slice_value('vendor_api.login') # => 'test_user'
 config.slice_value('vendor_api.port') # => Qonfig::UnknownSettingError # (key does not exist)
 ```
 
@@ -240,17 +250,17 @@ config.slice_value('vendor_api.port') # => Qonfig::UnknownSettingError # (key do
 # - each key (or key set) represents a requirement of a certain setting key;
 
 config.subet(:vendor_api, :enable_graphql)
-# => { 'vendor_api' => { 'user' => ..., 'host' => ... }, 'enable_graphql' => false }
+# => { 'vendor_api' => { 'login' => ..., 'domain' => ... }, 'enable_graphql' => false }
 
-config.subset(:project_id, [:vendor_api, :host], [:credentials, :user, :login])
-# => { 'project_id' => nil, 'host' => 'app.service.com', 'login' => 'D@iVeR' }
+config.subset(:project_id, [:vendor_api, :domain], [:credentials, :user, :login])
+# => { 'project_id' => nil, 'domain' => 'app.service.com', 'login' => 'D@iVeR' }
 ```
 
 - with dot-notation:
 
 ```ruby
-config.subset('project_id', 'vendor_api.host', 'credentials.user.login')
-# => { 'project_id' => nil, 'host' => 'app.service.com', 'login' => 'D@iVeR' }
+config.subset('project_id', 'vendor_api.domain', 'credentials.user.login')
+# => { 'project_id' => nil, 'domain' => 'app.service.com', 'login' => 'D@iVeR' }
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ require 'qonfig'
 
 - `setting(name, value)` - define setting with corresponding name and value;
 - `setting(name) { ... }` - define nested settings OR reopen existing nested setting and define some new nested settings;
-- `re_setting(name, value)`. `re_setting(name) { ... }` - re-define existing setting in `setting` method manner (or define new setting if the original setting does not exist);
+- `re_setting(name, value)`. `re_setting(name) { ... }` - re-define existing setting (or define new setting if the original setting does not exist);
 
 ```ruby
 # --- definition ---

--- a/lib/qonfig/commands/definition.rb
+++ b/lib/qonfig/commands/definition.rb
@@ -5,6 +5,7 @@
 module Qonfig::Commands::Definition
   require_relative 'definition/add_option'
   require_relative 'definition/add_nested_option'
+  require_relative 'definition/redefine_option'
   require_relative 'definition/compose'
   require_relative 'definition/load_from_yaml'
   require_relative 'definition/load_from_json'

--- a/lib/qonfig/commands/definition.rb
+++ b/lib/qonfig/commands/definition.rb
@@ -5,7 +5,7 @@
 module Qonfig::Commands::Definition
   require_relative 'definition/add_option'
   require_relative 'definition/add_nested_option'
-  require_relative 'definition/redefine_option'
+  require_relative 'definition/re_define_option'
   require_relative 'definition/compose'
   require_relative 'definition/load_from_yaml'
   require_relative 'definition/load_from_json'

--- a/lib/qonfig/commands/definition/re_define_option.rb
+++ b/lib/qonfig/commands/definition/re_define_option.rb
@@ -2,7 +2,7 @@
 
 # @api private
 # @since 0.20.0
-class Qonfig::Commands::Definition::RedefineOption < Qonfig::Commands::Base
+class Qonfig::Commands::Definition::ReDefineOption < Qonfig::Commands::Base
   # @since 0.20.0
   self.inheritable = true
 

--- a/lib/qonfig/commands/definition/redefine_option.rb
+++ b/lib/qonfig/commands/definition/redefine_option.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# @api private
+# @since 0.20.0
+class Qonfig::Commands::Definition::RedefineOption < Qonfig::Commands::Base
+  # @since 0.20.0
+  self.inheritable = true
+
+  # @return [Symbol, String]
+  #
+  # @api private
+  # @since 0.20.0
+  attr_reader :key
+
+  # @return [Object]
+  #
+  # @api private
+  # @since 0.20.0
+  attr_reader :value
+
+  # @return [Proc, NilClass]
+  #
+  # @api private
+  # @since 0.20.0
+  attr_reader :nested_data_set_klass
+
+  # @param key [Symbol, String]
+  # @param value [Object]
+  #
+  # @raise [Qonfig::ArgumentError]
+  # @raise [Qonfig::CoreMethodIntersectionError]
+  #
+  # @api private
+  # @since 0.20.0
+  def initialize(key, value, nested_definitions)
+    Qonfig::Settings::KeyGuard.prevent_incomparabilities!(key)
+
+    @key = key
+    @value = value
+    @nested_data_set_klass = Class.new(Qonfig::DataSet).tap do |data_set|
+      data_set.instance_eval(&nested_definitions)
+    end if nested_definitions
+  end
+
+  # @param data_set [Qonfig::DataSet]
+  # @param settings [Qonfig::Settings]
+  # @return [void]
+  #
+  # @api private
+  # @since 0.20.0
+  def call(data_set, settings)
+    if nested_data_set_klass
+      nested_settings = nested_data_set_klass.new.settings
+      nested_settings.__mutation_callbacks__.add(settings.__mutation_callbacks__)
+      settings.__define_setting__(key, nested_settings, with_redefinition: true)
+    else
+      settings.__define_setting__(key, value, with_redefinition: true)
+    end
+  end
+end

--- a/lib/qonfig/dsl.rb
+++ b/lib/qonfig/dsl.rb
@@ -113,8 +113,8 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   # @param nested_settings [Proc]
   # @return [void]
   #
-  # @see Qonfig::Commands::AddNestedOption
-  # @see Qonfig::Commands::AddOption
+  # @see Qonfig::Commands::Definition::AddNestedOption
+  # @see Qonfig::Commands::Definition::AddOption
   #
   # @api public
   # @since 0.1.0
@@ -131,10 +131,12 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   # @param nested_settings [Proc]
   # @return [void]
   #
+  # @see Qonfig::Comamnds::Definition::ReDefineOption
+  #
   # @api public
   # @since 0.20.0
   def re_setting(key, initial_value = nil, &nested_settings)
-    definition_commands << Qonfig::Commands::Definition::RedefineOption.new(
+    definition_commands << Qonfig::Commands::Definition::ReDefineOption.new(
       key, initial_value, nested_settings
     )
   end
@@ -142,7 +144,7 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   # @param data_set_klass [Class<Qonfig::DataSet>]
   # @return [void]
   #
-  # @see Qonfig::Comamnds::Compose
+  # @see Qonfig::Comamnds::Definition::Compose
   #
   # @api private
   # @sine 0.1.0
@@ -154,7 +156,7 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   # @option strict [Boolean]
   # @return [void]
   #
-  # @see Qonfig::Commands::LoadFromYAML
+  # @see Qonfig::Commands::Definition::LoadFromYAML
   #
   # @api public
   # @since 0.2.0
@@ -166,7 +168,7 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
 
   # @return [void]
   #
-  # @see Qonfig::Commands::LoadFromSelf
+  # @see Qonfig::Commands::Definition::LoadFromSelf
   #
   # @api public
   # @since 0.2.0
@@ -182,7 +184,7 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   # @option prefix [NilClass, String, Regexp]
   # @return [void]
   #
-  # @see Qonfig::Commands::LoadFromENV
+  # @see Qonfig::Commands::Definition::LoadFromENV
   #
   # @api public
   # @since 0.2.0
@@ -198,6 +200,8 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   # @option strict [Boolean]
   # @return [void]
   #
+  # @see Qonfig::Commands::Definition::LoadFromJSON
+  #
   # @api public
   # @since 0.5.0
   def load_from_json(file_path, strict: true)
@@ -209,6 +213,8 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   # @option via [Symbol]
   # @option env [Symbol, String]
   # @return [void]
+  #
+  # @see Qonfig::Commands::Definition::ExposeYAML
   #
   # @api public
   # @since 0.7.0
@@ -224,6 +230,8 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   # @option env [Symbol, String]
   # @return [void]
   #
+  # @see Qonfig::Commands::Definition::ExposeJSON
+  #
   # @api public
   # @since 0.14.0
   def expose_json(file_path, strict: true, via:, env:)
@@ -235,7 +243,7 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   # @option env [Symbol, String]
   # @return [void]
   #
-  # @see Qonfig::Commands::LoadFromSelf
+  # @see Qonfig::Commands::Definition::ExposeSelf
   #
   # @api public
   # @since 0.14.0
@@ -253,6 +261,8 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   # @option expose [NilClass, String, Symbol] Environment key
   # @return [void]
   #
+  # @see Qonfig::Commands::Instantiation::ValuesFile
+  #
   # @api public
   # @since 0.17.0
   def values_file(file_path, format: :dynamic, strict: false, expose: nil)
@@ -264,6 +274,8 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
   end
 
   # @return [void]
+  #
+  # @see Qonfig::Commands::Instantiation::FreezeState
   #
   # @api public
   # @since 0.19.0

--- a/lib/qonfig/dsl.rb
+++ b/lib/qonfig/dsl.rb
@@ -126,6 +126,19 @@ module Qonfig::DSL # rubocop:disable Metrics/ModuleLength
     end
   end
 
+  # @param key [Symbol, String]
+  # @param initial_value [Object]
+  # @param nested_settings [Proc]
+  # @return [void]
+  #
+  # @api public
+  # @since 0.20.0
+  def re_setting(key, initial_value = nil, &nested_settings)
+    definition_commands << Qonfig::Commands::Definition::RedefineOption.new(
+      key, initial_value, nested_settings
+    )
+  end
+
   # @param data_set_klass [Class<Qonfig::DataSet>]
   # @return [void]
   #

--- a/lib/qonfig/errors.rb
+++ b/lib/qonfig/errors.rb
@@ -68,6 +68,7 @@ module Qonfig
   # @see Qonfig::Settings::KeyGuard
   # @see Qonfig::Commands::Definition::AddOption
   # @see Qonfig::Commands::Definition::AddNestedOption
+  # @see Qonfig::Commands::Definition::ReDefineOption
   #
   # @api public
   # @since 0.2.0

--- a/lib/qonfig/plugins/toml.rb
+++ b/lib/qonfig/plugins/toml.rb
@@ -20,8 +20,8 @@ class Qonfig::Plugins::TOML < Qonfig::Plugins::Abstract
       require_relative 'toml/loaders/toml'
       require_relative 'toml/loaders/dynamic'
       require_relative 'toml/uploaders/toml'
-      require_relative 'toml/commands/load_from_toml'
-      require_relative 'toml/commands/expose_toml'
+      require_relative 'toml/commands/definition/load_from_toml'
+      require_relative 'toml/commands/definition/expose_toml'
       require_relative 'toml/data_set'
       require_relative 'toml/dsl'
     end

--- a/lib/qonfig/plugins/toml/commands/definition/expose_toml.rb
+++ b/lib/qonfig/plugins/toml/commands/definition/expose_toml.rb
@@ -2,7 +2,11 @@
 
 # @api private
 # @since 0.12.0
-class Qonfig::Commands::ExposeTOML < Qonfig::Commands::Base
+# @version 0.20.0
+class Qonfig::Commands::Definition::ExposeTOML < Qonfig::Commands::Base
+  # @since 0.20.0
+  self.inheritable = true
+
   # @return [Hash]
   #
   # @api private

--- a/lib/qonfig/plugins/toml/commands/definition/load_from_toml.rb
+++ b/lib/qonfig/plugins/toml/commands/definition/load_from_toml.rb
@@ -2,7 +2,11 @@
 
 # @api private
 # @since 0.12.0
-class Qonfig::Commands::LoadFromTOML < Qonfig::Commands::Base
+# @version 0.20.0
+class Qonfig::Commands::Definition::LoadFromTOML < Qonfig::Commands::Base
+  # @since 0.20.0
+  self.inheritable = true
+
   # @return [String]
   #
   # @api private

--- a/lib/qonfig/plugins/toml/dsl.rb
+++ b/lib/qonfig/plugins/toml/dsl.rb
@@ -7,10 +7,13 @@ module Qonfig::DSL
   # @option strict [Boolean]
   # @return [void]
   #
+  # @see Qonfig::Commands::Definition::LoadFromTOML
+  #
   # @api public
   # @since 0.12.0
+  # @version 0.20.0
   def load_from_toml(file_path, strict: true)
-    definition_commands << Qonfig::Commands::LoadFromTOML.new(
+    definition_commands << Qonfig::Commands::Definition::LoadFromTOML.new(
       file_path, strict: strict
     )
   end
@@ -21,10 +24,13 @@ module Qonfig::DSL
   # @option env [Symbol, String]
   # @return [void]
   #
+  # @see Qonfig::Commands::Definition::ExposeTOML
+  #
   # @api public
   # @since 0.12.0
+  # @version 0.20.0
   def expose_toml(file_path, strict: true, via:, env:)
-    definition_commands << Qonfig::Commands::ExposeTOML.new(
+    definition_commands << Qonfig::Commands::Definition::ExposeTOML.new(
       file_path, strict: strict, via: via, env: env
     )
   end

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -82,17 +82,21 @@ class Qonfig::Settings # NOTE: Layout/ClassStructure is disabled only for CORE_M
 
   # @param key [Symbol, String]
   # @param value [Object]
+  # @option with_redefinition [Boolean]
   # @return [void]
   #
   # @api private
   # @since 0.1.0
-  def __define_setting__(key, value) # rubocop:disable Metrics/AbcSize
+  # @version 0.20.0
+  def __define_setting__(key, value, with_redefinition: false) # rubocop:disable Metrics/AbcSize
     __lock__.thread_safe_definition do
       key = __indifferently_accessable_option_key__(key)
 
       __prevent_core_method_intersection__(key)
 
       case
+      when with_redefinition
+        __options__[key] = value
       when !__options__.key?(key)
         __options__[key] = value
       when __is_a_setting__(__options__[key]) && __is_a_setting__(value)

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -95,9 +95,7 @@ class Qonfig::Settings # NOTE: Layout/ClassStructure is disabled only for CORE_M
       __prevent_core_method_intersection__(key)
 
       case
-      when with_redefinition
-        __options__[key] = value
-      when !__options__.key?(key)
+      when with_redefinition || !__options__.key?(key)
         __options__[key] = value
       when __is_a_setting__(__options__[key]) && __is_a_setting__(value)
         __options__[key].__append_settings__(value)

--- a/spec/features/settings_redefinition_spec.rb
+++ b/spec/features/settings_redefinition_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Settings redefinition' do
-  specify do
+  specify '.re_setting DSL command' do
     class BaseRedefinableConfig < Qonfig::DataSet
       setting :nested do
         setting :some_key, 100_500

--- a/spec/features/settings_redefinition_spec.rb
+++ b/spec/features/settings_redefinition_spec.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
 describe 'Settings redefinition' do
-  pending 'write specs :)'
+  specify do
+    class BaseRedefinableConfig < Qonfig::DataSet
+      setting :nested do
+        setting :some_key, 100_500
+      end
+    end
+
+    class ChildRedefinitionConfig < BaseRedefinableConfig
+      re_setting :nested, :some_value
+    end
+
+    class AnotherChildRedefinitionConfig < BaseRedefinableConfig
+      re_setting :nested do
+        setting :another_key, 'test'
+      end
+    end
+
+    child_redefinition_config = ChildRedefinitionConfig.new
+    expect(child_redefinition_config[:nested]).to eq(:some_value)
+
+    another_child_redefinition_config = AnotherChildRedefinitionConfig.new
+    expect(another_child_redefinition_config[:nested][:another_key]).to eq('test')
+  end
 end

--- a/spec/features/settings_redefinition_spec.rb
+++ b/spec/features/settings_redefinition_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+describe 'Settings redefinition' do
+  pending 'write specs :)'
+end

--- a/spec/features/settings_redefinition_spec.rb
+++ b/spec/features/settings_redefinition_spec.rb
@@ -18,6 +18,9 @@ describe 'Settings redefinition' do
       end
     end
 
+    redefinable_config = BaseRedefinableConfig.new
+    expect(redefinable_config[:nested]).to eq(100_500)
+
     child_redefinition_config = ChildRedefinitionConfig.new
     expect(child_redefinition_config[:nested]).to eq(:some_value)
 

--- a/spec/features/settings_redefinition_spec.rb
+++ b/spec/features/settings_redefinition_spec.rb
@@ -19,7 +19,7 @@ describe 'Settings redefinition' do
     end
 
     redefinable_config = BaseRedefinableConfig.new
-    expect(redefinable_config[:nested]).to eq(100_500)
+    expect(redefinable_config[:nested][:some_key]).to eq(100_500)
 
     child_redefinition_config = ChildRedefinitionConfig.new
     expect(child_redefinition_config[:nested]).to eq(:some_value)


### PR DESCRIPTION
- new DSL command: `re_setting`
- works in `setting` manner but with one difference: instead of reopening existing nested settings it redefines them at all (creates new setting key without reopening);
- see `CHANGELOG.md`
- see `README.md`