### PR TITLE
[#load_from_x] Support for "do-config"-like configuration block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ All notable changes to this project will be documented in this file.
   - no any other useful functionality - just setting readers and setting writers;
   - can be instantiated by existing config object `Qonfig::DataSet#compacted` or by idrect instatiation `Qonfig::Compacted.new(config)`;
 - Added missing `#[]=(key, value)` accessor-method for `Qonfig::DataSet` objects;
-- Added support for instant `do |config|` configuration in `#load_from_self` / `#load_from_yaml` / `#load_from_json` / `#load_from_toml`
-  file-loading methods;
+- Added support for `do |config|` configuration block in `#load_from_self` / `#load_from_yaml` / `#load_from_json` / `#load_from_toml`
+  values-loading methods;
 - **Plugins** `pretty_print`:
   - added missing beautification logic for `Qonfig::Settings` objects;
   - added support for `Qonfig::Compacted` beautification;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
   - no any other useful functionality - just setting readers and setting writers;
   - can be instantiated by existing config object `Qonfig::DataSet#compacted` or by idrect instatiation `Qonfig::Compacted.new(config)`;
 - Added missing `#[]=(key, value)` accessor-method for `Qonfig::DataSet` objects;
-- Added support for instant block-style configuration in `#load_from_xxx` file-loading methods;
+- Added support for instant `do |config|` configuration in `#load_from_self` / `#load_from_yaml` / `#load_from_json` / `#load_from_toml`
+  file-loading methods;
 - **Plugins** `pretty_print`:
   - added missing beautification logic for `Qonfig::Settings` objects;
   - added support for `Qonfig::Compacted` beautification;

--- a/README.md
+++ b/README.md
@@ -2351,10 +2351,11 @@ config = Config.new # => Qonfig::FileNotFoundError
 ### Load setting values from YAML file (by instance)
 
 - prvoides an ability to load predefined setting values from a yaml file;
-- `#load_from_yaml(file_path, strict: true, expose: nil)`
+- `#load_from_yaml(file_path, strict: true, expose: nil, &configuration)`
   - `file_path` - full file path or `:self` (`:self` means "load setting values from __END__ data");
   - `:strict` - rerquires that file (or __END__-data) should exist (`true` by default);
   - `:expose` - what the environment-based subset of keys should be used (`nil` means "do not use any subset of keys") (`nil` by default);
+  - `&configuration` - `do |config|` ability :)
 
 #### Default behavior
 
@@ -2449,10 +2450,11 @@ config.settings.creds.auth_token # => "kek.pek" (from config.yml)
 ### Load setting values from JSON file (by instance)
 
 - prvoides an ability to load predefined setting values from a json file;
-- `#load_from_yaml(file_path, strict: true, expose: nil)`
+- `#load_from_yaml(file_path, strict: true, expose: nil, &configuration)`
   - `file_path` - full file path or `:self` (`:self` means "load setting values from __END__ data");
   - `:strict` - rerquires that file (or __END__-data) should exist (`true` by default);
   - `:expose` - what the environment-based subset of keys should be used (`nil` means "do not use any subset of keys") (`nil` by default);
+  - `&configuration` - `do |config|` ability :)
 
 #### Default behavior
 
@@ -2557,11 +2559,12 @@ config.settings.creds.auth_token # => "kek.pek" (from config.json)
 ### Load setting values from \_\_END\_\_ (by instance)
 
 - prvoides an ability to load predefined setting values from `__END__` file section;
-- `#load_from_self(strict: true, expose: nil)`
+- `#load_from_self(strict: true, expose: nil, &configuration)`
   - `:format` - defines the format of file (`:dynamic` means "try to automatically infer the file format") (`:dynamic` by default);
     - supports `:yaml`, `:json`, `:toml` (via `Qonfig.plugin(:toml)`), `:dynamic` (automatic format detection);
   - `:strict` - requires that __END__-data should exist (`true` by default);
   - `:expose` - what the environment-based subset of keys should be used (`nil` means "do not use any subset of keys") (`nil` by default);
+  - `&configuration` - `do |config|` ability :)
 
 #### Default behavior
 
@@ -2645,12 +2648,13 @@ __END__
 
 - prvoides an ability to load predefined setting values from a file;
 - works in instance-based `#load_from_yaml` / `#load_from_json` / `#load_from_self` manner;
-- signature: `#load_from_file(file_path, format: :dynamic, strict: true, expose: nil)`:
+- signature: `#load_from_file(file_path, format: :dynamic, strict: true, expose: nil, &configuration)`:
   - `file_path` - full file path or `:self` (`:self` means "load setting values from __END__ data");
   - `:format` - defines the format of file (`:dynamic` means "try to automatically infer the file format") (`:dynamic` by default);
     - supports `:yaml`, `:json`, `:toml` (via `Qonfig.plugin(:toml)`), `:dynamic` (automatic format detection);
   - `:strict` - rerquires that file (or __END__-data) should exist (`true` by default);
   - `:expose` - what the environment-based subset of keys should be used (`nil` means "do not use any subset of keys") (`nil` by default);
+  - `&configuration` - `do |config|` ability :)
 - see examples for instance-based `#load_from_yaml` ([doc](#load-setting-values-from-yaml-by-instance)) / `#load_from_json` ([doc](#load-setting-values-from-json-by-instance)) / `#load_from_self` ([doc](#load-setting-values-from-__end__-by-instance));
 
 ---

--- a/README.md
+++ b/README.md
@@ -2450,7 +2450,7 @@ config.settings.creds.auth_token # => "kek.pek" (from config.yml)
 ### Load setting values from JSON file (by instance)
 
 - prvoides an ability to load predefined setting values from a json file;
-- `#load_from_yaml(file_path, strict: true, expose: nil, &configuration)`
+- `#load_from_json(file_path, strict: true, expose: nil, &configuration)`
   - `file_path` - full file path or `:self` (`:self` means "load setting values from __END__ data");
   - `:strict` - rerquires that file (or __END__-data) should exist (`true` by default);
   - `:expose` - what the environment-based subset of keys should be used (`nil` means "do not use any subset of keys") (`nil` by default);

--- a/README.md
+++ b/README.md
@@ -2351,11 +2351,11 @@ config = Config.new # => Qonfig::FileNotFoundError
 ### Load setting values from YAML file (by instance)
 
 - prvoides an ability to load predefined setting values from a yaml file;
-- `#load_from_yaml(file_path, strict: true, expose: nil, &configuration)`
+- `#load_from_yaml(file_path, strict: true, expose: nil, &configurations)`
   - `file_path` - full file path or `:self` (`:self` means "load setting values from __END__ data");
   - `:strict` - rerquires that file (or __END__-data) should exist (`true` by default);
   - `:expose` - what the environment-based subset of keys should be used (`nil` means "do not use any subset of keys") (`nil` by default);
-  - `&configuration` - `do |config|` ability :)
+  - `&configurations` - `do |config|` ability :)
 
 #### Default behavior
 
@@ -2450,11 +2450,11 @@ config.settings.creds.auth_token # => "kek.pek" (from config.yml)
 ### Load setting values from JSON file (by instance)
 
 - prvoides an ability to load predefined setting values from a json file;
-- `#load_from_json(file_path, strict: true, expose: nil, &configuration)`
+- `#load_from_json(file_path, strict: true, expose: nil, &configurations)`
   - `file_path` - full file path or `:self` (`:self` means "load setting values from __END__ data");
   - `:strict` - rerquires that file (or __END__-data) should exist (`true` by default);
   - `:expose` - what the environment-based subset of keys should be used (`nil` means "do not use any subset of keys") (`nil` by default);
-  - `&configuration` - `do |config|` ability :)
+  - `&configurations` - `do |config|` ability :)
 
 #### Default behavior
 
@@ -2559,12 +2559,12 @@ config.settings.creds.auth_token # => "kek.pek" (from config.json)
 ### Load setting values from \_\_END\_\_ (by instance)
 
 - prvoides an ability to load predefined setting values from `__END__` file section;
-- `#load_from_self(strict: true, expose: nil, &configuration)`
+- `#load_from_self(strict: true, expose: nil, &configurations)`
   - `:format` - defines the format of file (`:dynamic` means "try to automatically infer the file format") (`:dynamic` by default);
     - supports `:yaml`, `:json`, `:toml` (via `Qonfig.plugin(:toml)`), `:dynamic` (automatic format detection);
   - `:strict` - requires that __END__-data should exist (`true` by default);
   - `:expose` - what the environment-based subset of keys should be used (`nil` means "do not use any subset of keys") (`nil` by default);
-  - `&configuration` - `do |config|` ability :)
+  - `&configurations` - `do |config|` ability :)
 
 #### Default behavior
 
@@ -2648,13 +2648,13 @@ __END__
 
 - prvoides an ability to load predefined setting values from a file;
 - works in instance-based `#load_from_yaml` / `#load_from_json` / `#load_from_self` manner;
-- signature: `#load_from_file(file_path, format: :dynamic, strict: true, expose: nil, &configuration)`:
+- signature: `#load_from_file(file_path, format: :dynamic, strict: true, expose: nil, &configurations)`:
   - `file_path` - full file path or `:self` (`:self` means "load setting values from __END__ data");
   - `:format` - defines the format of file (`:dynamic` means "try to automatically infer the file format") (`:dynamic` by default);
     - supports `:yaml`, `:json`, `:toml` (via `Qonfig.plugin(:toml)`), `:dynamic` (automatic format detection);
   - `:strict` - rerquires that file (or __END__-data) should exist (`true` by default);
   - `:expose` - what the environment-based subset of keys should be used (`nil` means "do not use any subset of keys") (`nil` by default);
-  - `&configuration` - `do |config|` ability :)
+  - `&configurations` - `do |config|` ability :)
 - see examples for instance-based `#load_from_yaml` ([doc](#load-setting-values-from-yaml-by-instance)) / `#load_from_json` ([doc](#load-setting-values-from-json-by-instance)) / `#load_from_self` ([doc](#load-setting-values-from-__end__-by-instance));
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,1 @@
+- specs for configuration block in Qonfig::DataSeet#load_from_xxx

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,0 @@
-- specs for configuration block in Qonfig::DataSeet#load_from_xxx

--- a/lib/qonfig/data_set.rb
+++ b/lib/qonfig/data_set.rb
@@ -96,6 +96,7 @@ class Qonfig::DataSet # rubocop:disable Metrics/ClassLength
   #
   # @api public
   # @since 0.17.0
+  # @version 0.21.0
   def load_from_file(file_path, format: :dynamic, strict: true, expose: nil, &configurations)
     thread_safe_access do
       load_setting_values_from_file(
@@ -114,6 +115,7 @@ class Qonfig::DataSet # rubocop:disable Metrics/ClassLength
   #
   # @api public
   # @since 0.17.0
+  # @version 0.21.0
   def load_from_yaml(file_path, strict: true, expose: nil, &configurations)
     load_from_file(file_path, format: :yml, strict: strict, expose: expose, &configurations)
   end
@@ -128,6 +130,7 @@ class Qonfig::DataSet # rubocop:disable Metrics/ClassLength
   #
   # @api public
   # @since 0.17.0
+  # @version 0.21.0
   def load_from_json(file_path, strict: true, expose: nil, &configurations)
     load_from_file(file_path, format: :json, strict: strict, expose: expose, &configurations)
   end
@@ -140,6 +143,7 @@ class Qonfig::DataSet # rubocop:disable Metrics/ClassLength
   #
   # @api public
   # @since 0.17.0
+  # @version 0.21.0
   def load_from_self(format: :dynamic, strict: true, expose: nil, &configurations)
     caller_location = caller(1, 1).first
 

--- a/lib/qonfig/plugins/toml/data_set.rb
+++ b/lib/qonfig/plugins/toml/data_set.rb
@@ -20,13 +20,14 @@ class Qonfig::DataSet
   # @param file_path [String]
   # @option strict [Boolean]
   # @option expose [NilClass, String, Symbol] Environment key
+  # @param configuration [Block]
   # @return [void]
   #
   # @see Qonfig::DataSet#load_from_file
   #
   # @api public
   # @since 0.17.0
-  def load_from_toml(file_path, strict: true, expose: nil)
-    load_from_file(file_path, format: :toml, strict: strict, expose: expose)
+  def load_from_toml(file_path, strict: true, expose: nil, &configuration)
+    load_from_file(file_path, format: :toml, strict: strict, expose: expose, &configuration)
   end
 end

--- a/lib/qonfig/plugins/toml/data_set.rb
+++ b/lib/qonfig/plugins/toml/data_set.rb
@@ -27,6 +27,7 @@ class Qonfig::DataSet
   #
   # @api public
   # @since 0.17.0
+  # @version 0.21.0
   def load_from_toml(file_path, strict: true, expose: nil, &configuration)
     load_from_file(file_path, format: :toml, strict: strict, expose: expose, &configuration)
   end


### PR DESCRIPTION
Example:

```ruby
app_config.load_from_file('app_config.yml') do |conf|
  conf.some_key_1 = :test
  conf.some_key_2 = false
  # and etc...
end
```

Added support for:

- `#load_from_file`
- `#load_from_yaml`
- `#load_from_json`
- `#load_from_toml`
- `#load_from_self`

See `CHANGELOG.md`
See `README.md`