### PR TITLE
[dot-notation] Hash representation with dot-notated keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- An ability to represent the config hash in dot-notated style (all config keys will be represented as dot-notated keys):
+  - works via `#to_h(dot_style: true)`;
+  - `key_transformer:` and `value_transfomer:` options are supported too;
+
+```ruby
+class Config << Qonfig::DataSet
+  setting :database do
+    setting :host, 'localhost'
+    setting :port, 6432
+  end
+
+  setting :api do
+    setting :rest_enabled, true
+    setting :rpc_enabled, false
+  end
+end
+
+Config.new.to_h(dot_style: true)
+# =>
+{
+  'database.host' => 'localhost',
+  'database.port' => 6432,
+  'api.rest_enabled' => true,
+  'api.rpc_enabled' => false,
+}
+```
+
 ## [0.24.1] - 2020-03-10
 ### Changed
 - Enhanced dot-notated key resolving algorithm: now it goes through the all dot-notated key parts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- An ability to represent the config hash in dot-notated style (all config keys will be represented as dot-notated keys):
+- An ability to represent the config hash in dot-notated style (all config keys are represented in dot-notated format):
   - works via `#to_h(dot_style: true)`;
   - `key_transformer:` and `value_transfomer:` options are supported too;
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ require 'qonfig'
   - [Inheritance](#inheritance)
   - [Composition](#composition)
   - [Hash representation](#hash-representation)
-    - [Default behaviour (without options)](#without-options-default-behavior)
+    - [Default behaviour (without options)](#default-behavior-without-options)
     - [With transformations](#with-transformations)
     - [Dot-style format](#dot-style-format)
   - [Smart Mixin](#smart-mixin) (`Qonfig::Configurable`)
@@ -465,11 +465,11 @@ class Config < Qonfig::DataSet
 end
 ```
 
-#### Without options (default behavior)
+#### Default behavior (without-options)
 
 ```ruby
 Config.new.to_h
-
+# =>
 {
   "serializers": {
     "json" => { "engine" => :ok },
@@ -485,11 +485,11 @@ Config.new.to_h
 - with `key_transformer` and/or `value_transformer`;
 
 ```ruby
-Config.new.to_h(
-  key_transformer: -> (key) { "#{key}!!" }
-  value_transformer: -> (value) { "#{value}??" }
-)
+key_transformer = -> (key) { "#{key}!!" }
+value_transformer = -> (value) { "#{value}??" }
 
+Config.new.to_h(key_transformer: key_transformer, value_transformer: value_transformer)
+# =>
 {
   "serializers!!": {
     "json!!" => { "engine!!" => "ok??" },

--- a/README.md
+++ b/README.md
@@ -436,6 +436,12 @@ project_config.settings.db.password # => 'testpaswd'
 
 ### Hash representation
 
+- works via `#to_h` and `#to_hash`;
+- supported options:
+  - `key_transformer:` - an optional proc that accepts setting key and makes your custom transformations;
+  - `value_transformer:` - an optional proc that accepts setting value and makes your custom transformations;
+  - `dot_style:` - (`false` by default) represent setting keys in dot-notation (transformations are supported too);
+
 ```ruby
 class Config < Qonfig::DataSet
   setting :serializers do
@@ -454,7 +460,11 @@ class Config < Qonfig::DataSet
 
   setting :logger, Logger.new(STDOUT)
 end
+```
 
+#### Without options (default behavior)
+
+```ruby
 Config.new.to_h
 
 {
@@ -464,6 +474,53 @@ Config.new.to_h
   },
   "adapter" => { "default" => :memory_sync },
   "logger" => #<Logger:0x4b0d79fc>
+}
+```
+
+#### With transformations
+
+- with `key_transformer` and/or `value_transformer`;
+
+```ruby
+Config.new.to_h(
+  key_transformer: -> (key) { "#{key}!!" }
+  value_transformer: -> (value) { "#{value}??" }
+)
+
+{
+  "serializers!!": {
+    "json!!" => { "engine!!" => "ok??" },
+    "hash!!" => { "engine!!" => "native??" },
+  },
+  "adapter!!" => { "default!!" => "memory_sync??" },
+  "logger!!" => "#<Logger:0x00007fcde799f158>??"
+}
+```
+
+#### Dot-style
+
+- transformations are supported too (`key_transformer` and `value_transformer`);
+
+```ruby
+Config.new.to_h(dot_style: true)
+# =>
+{
+  "serializers.json.engine" => :ok,
+  "serializers.hash.engine" => :native,
+  "adapter.default" => :memory_sync,
+  "logger" => #<Logger:0x4b0d79fc>,
+}
+```
+
+```ruby
+transformer = -> (value) { "$$#{value}$$" }
+Config.new.to_h(dot_style: true, key_transformer: transformer, value_transformer: transformer)
+# => "#<Logger:0x00007fcde799f158>??"
+{
+  "$$serializers.json.engine$$" => "$$ok$$",
+  "$$serializers.hash.engine$$" => "$$native$$",
+  "$$adapter.default$$" => "$$memory_sync$$",
+  "$$logger$$" => "$$#<Logger:0x00007fcde799f158>$$",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ require 'qonfig'
   - [Inheritance](#inheritance)
   - [Composition](#composition)
   - [Hash representation](#hash-representation)
+    - [Default behaviour (without options)](#without-options-default-behavior)
+    - [With transformations](#with-transformations)
+    - [Dot-style format](#dot-style-format)
   - [Smart Mixin](#smart-mixin) (`Qonfig::Configurable`)
   - [Instantiation without class definition](#instantiation-without-class-definition) (`Qonfig::DataSet.build(&definitions)`)
 - [Compacted config](#compacted-config)
@@ -497,7 +500,7 @@ Config.new.to_h(
 }
 ```
 
-#### Dot-style
+#### Dot-style format
 
 - transformations are supported too (`key_transformer` and `value_transformer`);
 
@@ -514,7 +517,9 @@ Config.new.to_h(dot_style: true)
 
 ```ruby
 transformer = -> (value) { "$$#{value}$$" }
+
 Config.new.to_h(dot_style: true, key_transformer: transformer, value_transformer: transformer)
+
 # => "#<Logger:0x00007fcde799f158>??"
 {
   "$$serializers.json.engine$$" => "$$ok$$",

--- a/lib/qonfig/data_set.rb
+++ b/lib/qonfig/data_set.rb
@@ -184,6 +184,7 @@ class Qonfig::DataSet # rubocop:disable Metrics/ClassLength
     end
   end
 
+  # @option dot_style [Boolean]
   # @option key_transformer [Proc]
   # @option value_transformer [Proc]
   # @return [Hash]
@@ -191,11 +192,13 @@ class Qonfig::DataSet # rubocop:disable Metrics/ClassLength
   # @api public
   # @since 0.1.0
   def to_h(
+    dot_style: Qonfig::Settings::REPRESENT_HASH_IN_DOT_STYLE,
     key_transformer: Qonfig::Settings::BASIC_SETTING_KEY_TRANSFORMER,
     value_transformer: Qonfig::Settings::BASIC_SETTING_VALUE_TRANSFORMER
   )
     thread_safe_access do
       settings.__to_hash__(
+        dot_notation: dot_style,
         transform_key: key_transformer,
         transform_value: value_transformer
       )

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -246,7 +246,7 @@ class Qonfig::Settings # NOTE: Layout/ClassStructure is disabled only for CORE_M
           transform_value: transform_value
         )
       else
-        __build_hash_representation__(
+        __build_basic_hash_representation__(
           transform_key: transform_key,
           transform_value: transform_value
         )
@@ -714,14 +714,15 @@ class Qonfig::Settings # NOTE: Layout/ClassStructure is disabled only for CORE_M
   # @return [Hash]
   #
   # @api private
-  # @since 0.2.0
-  def __build_hash_representation__(options_part = __options__, transform_key:, transform_value:)
+  # @since 0.25.0
+  # rubocop:disable Layout/LineLength
+  def __build_basic_hash_representation__(options_part = __options__, transform_key:, transform_value:)
     options_part.each_with_object({}) do |(key, value), hash|
       final_key = transform_key.call(key)
 
       case
       when value.is_a?(Hash)
-        hash[final_key] = __build_hash_representation__(
+        hash[final_key] = __build_basic_hash_representation__(
           value,
           transform_key: transform_key,
           transform_value: transform_value
@@ -737,6 +738,7 @@ class Qonfig::Settings # NOTE: Layout/ClassStructure is disabled only for CORE_M
       end
     end
   end
+  # rubocop:enable Layout/LineLength
 
   # @option transform_key [Proc]
   # @option transform_value [Proc]

--- a/lib/qonfig/settings.rb
+++ b/lib/qonfig/settings.rb
@@ -745,11 +745,13 @@ class Qonfig::Settings # NOTE: Layout/ClassStructure is disabled only for CORE_M
   # @api private
   # @since 0.25.0
   def __build_dot_notated_hash_representation__(transform_key:, transform_value:)
-    __setting_keys__.each_with_object({}) do |key, hash|
-      final_key = transform_key.call(key)
-      final_value = transform_value.call(__resolve_value__(key))
+    {}.tap do |hash|
+      __deep_each_key_value_pair__ do |setting_key, setting_value|
+        final_key = transform_key.call(setting_key)
+        final_value = transform_value.call(setting_value)
 
-      hash[final_key] = final_value
+        hash[final_key] = final_value
+      end
     end
   end
 

--- a/spec/features/dot_notation_spec.rb
+++ b/spec/features/dot_notation_spec.rb
@@ -106,4 +106,52 @@ describe 'Dot-notation' do
     expect { config['kek.frek']['bek'] }.to raise_error(Qonfig::UnknownSettingError)
     expect { config['lel'] }.to raise_error(Qonfig::UnknownSettingError)
   end
+
+  describe '#to_h' do
+    specify 'default behavior' do
+      expect(config.to_h(dot_style: true)).to match(
+        'kek.pek.cheburek' => 'test',
+        'kek.foo.bar' => 100_500,
+        'kek.frek.jek.bek' => 123_456
+      )
+    end
+
+    specify 'with key and value transformations' do
+      transformer = -> (value) { "#{value}!!" }
+
+      # transformations: key ONLY
+      hash = config.to_h(
+        dot_style: true,
+        key_transformer: transformer
+      )
+      expect(hash).to match(
+        'kek.pek.cheburek!!' => 'test',
+        'kek.foo.bar!!' => 100_500,
+        'kek.frek.jek.bek!!' => 123_456
+      )
+
+      # transformations: value ONLY
+      hash = config.to_h(
+        dot_style: true,
+        value_transformer: transformer
+      )
+      expect(hash).to match(
+        'kek.pek.cheburek' => 'test!!',
+        'kek.foo.bar' => '100500!!',
+        'kek.frek.jek.bek' => '123456!!'
+      )
+
+      # transformations: key AND value
+      hash = config.to_h(
+        dot_style: true,
+        key_transformer: transformer,
+        value_transformer: transformer
+      )
+      expect(hash).to match(
+        'kek.pek.cheburek!!' => 'test!!',
+        'kek.foo.bar!!' => '100500!!',
+        'kek.frek.jek.bek!!' => '123456!!'
+      )
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'simplecov'
 
 SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
-SimpleCov.minimum_coverage(100) # if !!ENV['FULL_TEST_COVERAGE_CHECK']
+SimpleCov.minimum_coverage(100) if !!ENV['FULL_TEST_COVERAGE_CHECK']
 SimpleCov.start do
   enable_coverage :branch
   add_filter 'spec'


### PR DESCRIPTION
- See `README.md`
- See `CHANGELOG.md`

Example:

```ruby
class Config << Qonfig::DataSet
  setting :database do
    setting :host, 'localhost'
    setting :port, 6432
  end

  setting :api do
    setting :rest_enabled, true
    setting :rpc_enabled, false
  end
end

Config.new.to_h(dot_style: true)
# =>
{
  'database.host' => 'localhost',
  'database.port' => 6432,
  'api.rest_enabled' => true,
  'api.rpc_enabled' => false,
}
```