### PR TITLE
Add file data resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.25.0] - 2020-10-20
+### Added
+- Added file data resolver functionality:
+  - Added resolver for `file`
+  - Added resolver for `vault`
+  - Added DSL methods for defining custom resolvers
+
+```ruby
+Qonfig.define_resolver(:https) do |file_path|
+  Net::HTTP.get(URI("https:://#{file_path}"))
+end
+
+class Config < Qonfig::DataSet
+  load_from_yaml "https://yamlhost.com/cool.yaml"
+end
+```
+
 ## [0.25.0] - 2020-09-15
 ### Added
 - Support for **Vault** config provider:

--- a/README.md
+++ b/README.md
@@ -2049,6 +2049,8 @@ end
 - **Daily work**
   - [Save to JSON file](#save-to-json-file) (`save_to_json`)
   - [Save to YAML file](#save-to-yaml-file) (`save_to_yaml`)
+- **Define file data resolvers**
+  - [Working with file data resolvers](#working-with-file-data-resolvers)
 
 ---
 
@@ -3154,6 +3156,35 @@ dynamic: 10
 
 ---
 
+### Working with file data resolvers
+
+You can define custom file data resolver
+
+```ruby
+Qonfig.define_resolver(:http) do |file_path|
+  final_url = URI("http://#{file_path}")
+  Net::HTTP.get(final_url)
+rescue SocketError => error
+  raise Qonfig::FileNotFoundError, error.message
+end
+
+class AppConfig < Qonfig::DataSet
+  load_from_yaml "http://content-holder.com/settings.yml"
+end
+```
+
+Also, you can set this file data resolver to default resolver.
+
+```ruby
+Qonfig.set_default_resolver :http
+
+class AppConfig < Qonfig::DataSet
+  load_from_yaml "content-holder.com/settings.yml" # same as previous example
+end
+```
+
+---
+
 ### Plugins
 
 - [toml](#plugins-toml) (provides `load_from_toml`, `save_to_toml`, `expose_toml`);
@@ -3289,6 +3320,7 @@ config = Config.new
 - depends on `vault` gem ([link](https://github.com/hashicorp/vault-ruby)) (tested on `>= 0.1`);
 - provides `.load_from_vault` (works in `.load_from_yaml` manner ([doc](#load-from-yaml-file)));
 - provides `.expose_vault` (works in `.expose_yaml` manner ([doc](#expose-yaml)));
+- provides custom file data resolver `vault://path/to/file/key.yml`;
 
 ```ruby
 # 1) require external dependency

--- a/lib/qonfig.rb
+++ b/lib/qonfig.rb
@@ -22,6 +22,7 @@ module Qonfig
   require_relative 'qonfig/imports'
   require_relative 'qonfig/plugins'
   require_relative 'qonfig/compacted'
+  require_relative 'qonfig/file_data_resolving'
 
   # @api public
   # @since 0.4.0
@@ -30,6 +31,10 @@ module Qonfig
   # @api public
   # @since 0.20.0
   extend Validation::PredefinitionMixin
+
+  # @api public
+  # @since 0.25.1
+  extend FileDataResolving::Mixin
 
   # @since 0.20.0
   define_validator(:integer) { |value| value.is_a?(Integer) }
@@ -59,6 +64,15 @@ module Qonfig
   define_validator(:module) { |value| value.is_a?(Module) }
   # @since 0.20.0
   define_validator(:not_nil) { |value| !value.nil? }
+
+  # @since 0.25.1
+  define_resolver(:file) do |file_path|
+    ::File.read(file_path)
+  rescue Errno::ENOENT => error
+    raise Qonfig::FileNotFoundError, error.message
+  end
+  # @since 0.25.1
+  set_default_resolver :file
 
   # @since 0.12.0
   register_plugin('toml', Qonfig::Plugins::TOML)

--- a/lib/qonfig/file_data_resolving.rb
+++ b/lib/qonfig/file_data_resolving.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# @api private
+# @since 0.25.1
+module Qonfig::FileDataResolving
+  require_relative 'file_data_resolving/resolver'
+  require_relative 'file_data_resolving/mixin'
+end

--- a/lib/qonfig/file_data_resolving/mixin.rb
+++ b/lib/qonfig/file_data_resolving/mixin.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# @api public
+# @since 0.25.1
+module Qonfig::FileDataResolving::Mixin
+  # @param scheme_name [Symbol,String]
+  # @param block [Block]
+  # @return [void]
+  #
+  # @api public
+  # @since 0.25.1
+  def define_resolver(scheme_name, &block)
+    Qonfig::FileDataResolving::Resolver.add_resolver!(scheme_name, block)
+  end
+
+  # @param scheme_name [Symbol,String]
+  # @return [void]
+  #
+  # @api public
+  # @since 0.25.1
+  def set_default_resolver(scheme_name)
+    Qonfig::FileDataResolving::Resolver.set_default_resolver!(scheme_name)
+  end
+end

--- a/lib/qonfig/file_data_resolving/resolver.rb
+++ b/lib/qonfig/file_data_resolving/resolver.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# @api private
+# @since 0.25.1
+class Qonfig::FileDataResolving::Resolver
+  class << self
+    # @param scheme [Symbol,String]
+    # @param resolver_proc [Proc]
+    # @return [void]
+    #
+    # @api private
+    # @since 0.25.1
+    def add_resolver!(scheme, resolver_proc)
+      self.resolvers ||= {}
+      resolvers[scheme.to_sym] = resolver_proc
+    end
+
+    # @param scheme_name [Symbol,String]
+    # @return [void]
+    #
+    # @api private
+    # @since 0.25.1
+    def set_default_resolver!(scheme_name)
+      self.default_resolver = resolvers[scheme_name.to_sym]
+    end
+
+    # @param file_path [String,Pathname]
+    # @return [String]
+    # @raise [Qonfig::FileNotFoundError]
+    #
+    # @api private
+    # @since 0.25.1
+    def resolve!(file_path)
+      scheme_name = URI(file_path.to_s).scheme&.to_sym
+      resolver = resolvers[scheme_name] || default_resolver
+      resolver.call(file_path.to_s.split('://').last)
+    end
+
+    private
+
+    # @return [Array<Proc>]
+    #
+    # @api private
+    # @since 0.25.1
+    attr_accessor :resolvers
+
+    # @return [Proc]
+    #
+    # @api private
+    # @since 0.25.1
+    attr_accessor :default_resolver
+  end
+end

--- a/lib/qonfig/loaders/basic.rb
+++ b/lib/qonfig/loaders/basic.rb
@@ -30,9 +30,10 @@ class Qonfig::Loaders::Basic
     # @api private
     # @since 0.5.0
     def load_file(file_path, fail_on_unexist: true)
-      load(::File.read(file_path))
-    rescue Errno::ENOENT => error
-      fail_on_unexist ? (raise Qonfig::FileNotFoundError, error.message) : load_empty_data
+      data = Qonfig::FileDataResolving::Resolver.resolve!(file_path)
+      load(data)
+    rescue Qonfig::FileNotFoundError
+      fail_on_unexist ? raise : load_empty_data
     end
   end
 end

--- a/lib/qonfig/plugins/vault.rb
+++ b/lib/qonfig/plugins/vault.rb
@@ -19,6 +19,25 @@ class Qonfig::Plugins::Vault < Qonfig::Plugins::Abstract
       require_relative 'vault/commands/definition/load_from_vault'
       require_relative 'vault/commands/definition/expose_vault'
       require_relative 'vault/dsl'
+
+      define_resolvers!
+    end
+
+    private
+
+    # @return [void]
+    #
+    # @since 0.25.1
+    # @api private
+    def define_resolvers!
+      ::Qonfig.define_resolver(:vault) do |file_path|
+        *vault_path, file_name = file_path.split('/')
+        result = Qonfig::Loaders::Vault.load_file(vault_path.join('/'))[file_name.to_sym]
+        if result == nil
+          raise Qonfig::FileNotFoundError, "Can't load file with name #{file_name}"
+        end
+        result
+      end
     end
   end
 end

--- a/lib/qonfig/plugins/vault/loaders/vault.rb
+++ b/lib/qonfig/plugins/vault/loaders/vault.rb
@@ -20,12 +20,14 @@ class Qonfig::Loaders::Vault < Qonfig::Loaders::Basic
     #
     # @api private
     # @since 0.25.0
-    def load_file(path, fail_on_unexist: true)
+    def load_file(path, fail_on_unexist: true, transform_values: true)
       data = ::Vault.with_retries(Vault::HTTPError) do
         ::Vault.logical.read(path.to_s)&.data&.dig(:data)
       end
       raise Qonfig::FileNotFoundError, "Path #{path} not exist" if data.nil? && fail_on_unexist
       result = data || empty_data
+      return result unless transform_values
+
       deep_transform_values(result)
     rescue Vault::VaultError => error
       raise(Qonfig::VaultLoaderError.new(error.message).tap do |exception|

--- a/lib/qonfig/version.rb
+++ b/lib/qonfig/version.rb
@@ -5,5 +5,5 @@ module Qonfig
   #
   # @api public
   # @since 0.1.0
-  VERSION = '0.25.0'
+  VERSION = '0.25.1'
 end

--- a/spec/features/plugins/vault/load_from_yaml_spec.rb
+++ b/spec/features/plugins/vault/load_from_yaml_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe 'Plugins(vault): Load yaml from vault kv store', plugin: :vault do
+  before { stub_const('VaultConfig', vault_class) }
+
+  before { allow(Vault).to receive(:logical).and_return(logical_double) }
+
+  let(:returned_data) do
+    instance_double(Vault::Secret).tap do |instance|
+      allow(instance).to receive(:data).and_return(secret_data)
+    end
+  end
+  let(:logical_double) { instance_double(Vault::Logical) }
+  let(:secret_data) { Hash[data: { "file.yml": yaml_content }] }
+  let(:yaml_content) { YAML.dump(kek: "pek") }
+
+  let(:vault_class) do
+    Class.new(Qonfig::DataSet) do
+      load_from_yaml 'vault://kv/data/development/file.yml'
+    end
+  end
+
+  specify 'defines config object by yaml instructions' do
+    expect(Vault.logical).to receive(:read).with('kv/data/development').and_return(returned_data)
+    VaultConfig.new.settings.tap do |conf|
+      expect(conf).to have_attributes(kek: "pek",)
+    end
+  end
+
+  context "when key doesn't exist" do
+    let(:secret_data) { Hash[data: { "other_file.yml": yaml_content }] }
+
+    specify "raises error" do
+      expect(Vault.logical).to receive(:read).with('kv/data/development').and_return(returned_data)
+      expect { VaultConfig.new }.to raise_error(Qonfig::FileNotFoundError)
+    end
+  end
+end


### PR DESCRIPTION
We can use scheme in file_path to specify how we should load file content. So, I implement file content resolving logic:

- Add `DSL` methods, which helps define custom resolvers
- Add `file` resolver
- Add `vault` resolver in `Vault ` gem